### PR TITLE
Update requirements.txt for railway deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,16 @@ uv run fastapi dev         # Start development server (http://localhost:8000, au
 
 API docs available at `http://localhost:8000/docs` when running.
 
+## Deployment (Railway)
+
+When adding or updating dependencies in `pyproject.toml`, regenerate `requirements.txt`:
+
+```bash
+uv export --no-hashes > requirements.txt
+```
+
+Railway uses `requirements.txt` for deployment. Dev dependencies (in `[dependency-groups] dev`) are excluded automatically.
+
 ## Architecture Overview
 
 FastAPI backend using Supabase for authentication and database. Python 3.12+, managed with UV package manager.

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,6 +74,7 @@ httpx==0.28.1
     #   supabase
     #   supabase-auth
     #   supabase-functions
+    #   upstash-redis
 hyperframe==6.1.0
     # via h2
 idna==3.11
@@ -159,6 +160,7 @@ rich-toolkit==0.17.1
     #   fastapi-cloud-cli
 rignore==0.7.6
     # via fastapi-cloud-cli
+ruff==0.14.13
 sentry-sdk==2.49.0
     # via fastapi-cloud-cli
 shellingham==1.5.4
@@ -203,6 +205,8 @@ typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings
+upstash-redis==1.5.0
+    # via ludo-stacked-backend
 urllib3==2.6.3
     # via
     #   requests


### PR DESCRIPTION
This pull request adds deployment instructions specific to Railway to the `CLAUDE.md` documentation. It clarifies how to manage dependencies for deployment by updating `requirements.txt` using the `uv` tool and explains how Railway handles dev dependencies.

Documentation updates:

* Added a "Deployment (Railway)" section to `CLAUDE.md` with instructions for regenerating `requirements.txt` using `uv export --no-hashes`, and clarified that Railway uses this file for deployment while excluding dev dependencies.…regeneration