### PR TITLE
feat: Implement message-based authentication for WebSocket connections

### DIFF
--- a/app/schemas/ws.py
+++ b/app/schemas/ws.py
@@ -10,6 +10,11 @@ from pydantic import BaseModel, Field
 class MessageType(str, Enum):
     """WebSocket message types."""
 
+    # Authentication
+    AUTHENTICATE = "authenticate"
+    AUTHENTICATED = "authenticated"
+
+    # Core
     PING = "ping"
     PONG = "pong"
     CONNECTED = "connected"
@@ -38,6 +43,7 @@ class WSCloseCode:
     AUTH_EXPIRED = 4002
     ROOM_NOT_FOUND = 4003
     ROOM_ACCESS_DENIED = 4004
+    AUTH_TIMEOUT = 4005
 
 
 class WSClientMessage(BaseModel):
@@ -119,3 +125,19 @@ class JoinRoomPayload(BaseModel):
     """Payload for the 'join_room' message from client."""
 
     room_code: str = Field(..., min_length=6, max_length=6, pattern="^[A-Z0-9]{6}$")
+
+
+class AuthenticatePayload(BaseModel):
+    """Payload for the 'authenticate' message from client."""
+
+    token: str = Field(..., min_length=1)
+    room_code: str = Field(..., min_length=6, max_length=6, pattern="^[A-Z0-9]{6}$")
+
+
+class AuthenticatedPayload(BaseModel):
+    """Payload for the 'authenticated' message sent to client on successful auth."""
+
+    connection_id: str
+    user_id: str
+    server_id: str
+    room: RoomSnapshot

--- a/app/services/websocket/handlers/__init__.py
+++ b/app/services/websocket/handlers/__init__.py
@@ -60,6 +60,7 @@ async def dispatch(ctx: HandlerContext) -> HandlerResult | None:
 
 
 # Import handlers to trigger registration
+from . import authenticate  # noqa: E402, F401
 from . import leave  # noqa: E402, F401
 from . import ping  # noqa: E402, F401
 from . import ready  # noqa: E402, F401

--- a/app/services/websocket/handlers/authenticate.py
+++ b/app/services/websocket/handlers/authenticate.py
@@ -1,0 +1,156 @@
+"""Handler for WebSocket authentication messages."""
+
+import logging
+
+from app.schemas.ws import (
+    AuthenticatePayload,
+    MessageType,
+    WSServerMessage,
+)
+from app.services.room.service import get_room_service
+from app.services.websocket.auth import get_ws_authenticator
+
+from . import handler
+from .base import (
+    HandlerContext,
+    HandlerResult,
+    error_response,
+    snapshot_to_pydantic,
+    validate_payload,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@handler(MessageType.AUTHENTICATE)
+async def handle_authenticate(ctx: HandlerContext) -> HandlerResult:
+    """Handle authentication request from client.
+
+    Client sends: { type: "authenticate", payload: { token: "...", room_code: "ABC123" } }
+
+    On success: Authenticates connection, subscribes to room, sends room snapshot.
+    On failure: Sends error response (connection remains open but unauthenticated).
+    """
+    # Check if already authenticated
+    connection = ctx.manager.get_connection(ctx.connection_id)
+    if connection is None:
+        return error_response(
+            "CONNECTION_NOT_FOUND",
+            "Connection not found",
+            MessageType.ERROR,
+            ctx.message.request_id,
+        )
+
+    if connection.authenticated:
+        return error_response(
+            "ALREADY_AUTHENTICATED",
+            "Connection is already authenticated",
+            MessageType.ERROR,
+            ctx.message.request_id,
+        )
+
+    # Validate payload
+    payload, error = validate_payload(
+        ctx.message.payload,
+        AuthenticatePayload,
+        ctx.message.request_id,
+        MessageType.ERROR,
+    )
+    if error:
+        return error
+
+    # Validate token
+    authenticator = get_ws_authenticator()
+    auth_result = await authenticator.validate_token(payload.token)
+
+    if not auth_result.success:
+        error_code = "AUTH_EXPIRED" if auth_result.expired else "AUTH_FAILED"
+        logger.warning(
+            "Authentication failed for connection %s: %s",
+            ctx.connection_id,
+            auth_result.error,
+        )
+        return error_response(
+            error_code,
+            auth_result.error or "Authentication failed",
+            MessageType.ERROR,
+            ctx.message.request_id,
+        )
+
+    user_id = auth_result.payload.get("sub") if auth_result.payload else None
+    if not user_id:
+        logger.warning(
+            "Authentication failed for connection %s: missing user_id in token",
+            ctx.connection_id,
+        )
+        return error_response(
+            "AUTH_FAILED",
+            "Invalid token: missing user_id",
+            MessageType.ERROR,
+            ctx.message.request_id,
+        )
+
+    # Validate room access
+    room_service = get_room_service()
+    room_id, error_msg = await room_service.validate_room_access(user_id, payload.room_code)
+    if error_msg:
+        logger.warning(
+            "Room access denied for user %s, connection %s: %s (room_code=%s)",
+            user_id,
+            ctx.connection_id,
+            error_msg,
+            payload.room_code,
+        )
+        error_code = "ROOM_NOT_FOUND" if error_msg == "ROOM_NOT_FOUND" else "ROOM_ACCESS_DENIED"
+        return error_response(
+            error_code,
+            f"Room access denied: {error_msg}",
+            MessageType.ERROR,
+            ctx.message.request_id,
+        )
+
+    # Update seat connected status
+    await room_service.update_seat_connected_by_user(room_id, user_id, connected=True)
+
+    # Get fresh room snapshot
+    room_snapshot_data = await room_service.get_room_snapshot(room_id)
+    if not room_snapshot_data:
+        logger.error("Room %s not found in Redis after auth succeeded", room_id)
+        return error_response(
+            "ROOM_NOT_FOUND",
+            "Room not found",
+            MessageType.ERROR,
+            ctx.message.request_id,
+        )
+
+    room_snapshot = snapshot_to_pydantic(room_snapshot_data)
+
+    # Authenticate the connection (this sends the AUTHENTICATED message)
+    success = await ctx.manager.authenticate_connection(
+        ctx.connection_id, user_id, room_id, room_snapshot
+    )
+    if not success:
+        return error_response(
+            "AUTH_FAILED",
+            "Failed to authenticate connection",
+            MessageType.ERROR,
+            ctx.message.request_id,
+        )
+
+    logger.info(
+        "Connection %s authenticated for user %s in room %s",
+        ctx.connection_id,
+        user_id,
+        payload.room_code,
+    )
+
+    # Broadcast room update to other members
+    return HandlerResult(
+        success=True,
+        response=None,  # AUTHENTICATED message already sent by authenticate_connection
+        broadcast=WSServerMessage(
+            type=MessageType.ROOM_UPDATED,
+            payload=room_snapshot.model_dump(),
+        ),
+        room_id=room_id,
+    )

--- a/app/services/websocket/handlers/base.py
+++ b/app/services/websocket/handlers/base.py
@@ -134,6 +134,26 @@ def error_response(
     )
 
 
+def require_authenticated(ctx: "HandlerContext") -> HandlerResult | None:
+    """Check if connection is authenticated.
+
+    Args:
+        ctx: The handler context.
+
+    Returns:
+        HandlerResult with error if not authenticated, None if authenticated.
+    """
+    connection = ctx.manager.get_connection(ctx.connection_id)
+    if connection is None or not connection.authenticated:
+        return error_response(
+            "NOT_AUTHENTICATED",
+            "Authentication required. Send an 'authenticate' message first.",
+            MessageType.ERROR,
+            ctx.message.request_id,
+        )
+    return None
+
+
 def snapshot_to_pydantic(snapshot: RoomSnapshotData) -> RoomSnapshot:
     """Convert a dataclass RoomSnapshotData to a Pydantic RoomSnapshot."""
     return RoomSnapshot(

--- a/app/services/websocket/handlers/leave.py
+++ b/app/services/websocket/handlers/leave.py
@@ -6,7 +6,13 @@ from app.schemas.ws import MessageType, RoomClosedPayload, WSServerMessage
 from app.services.room.service import get_room_service
 
 from . import handler
-from .base import HandlerContext, HandlerResult, error_response, snapshot_to_pydantic
+from .base import (
+    HandlerContext,
+    HandlerResult,
+    error_response,
+    require_authenticated,
+    snapshot_to_pydantic,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +24,11 @@ async def handle_leave_room(ctx: HandlerContext) -> HandlerResult:
     If host leaves: close room, broadcast ROOM_CLOSED to all.
     If player leaves: clear seat, broadcast ROOM_UPDATED to remaining players.
     """
+    # Require authentication
+    auth_error = require_authenticated(ctx)
+    if auth_error:
+        return auth_error
+
     # Get connection to find room_id
     connection = ctx.manager.get_connection(ctx.connection_id)
     if connection is None or connection.room_id is None:

--- a/app/services/websocket/handlers/ready.py
+++ b/app/services/websocket/handlers/ready.py
@@ -6,7 +6,13 @@ from app.schemas.ws import MessageType, WSServerMessage
 from app.services.room.service import get_room_service
 
 from . import handler
-from .base import HandlerContext, HandlerResult, error_response, snapshot_to_pydantic
+from .base import (
+    HandlerContext,
+    HandlerResult,
+    error_response,
+    require_authenticated,
+    snapshot_to_pydantic,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +23,11 @@ async def handle_toggle_ready(ctx: HandlerContext) -> HandlerResult:
 
     Returns room snapshot to requester and broadcasts to all room members.
     """
+    # Require authentication
+    auth_error = require_authenticated(ctx)
+    if auth_error:
+        return auth_error
+
     # Get connection to find room_id
     connection = ctx.manager.get_connection(ctx.connection_id)
     if connection is None or connection.room_id is None:


### PR DESCRIPTION
This pull request introduces a major overhaul of the WebSocket authentication flow, moving from connection-time JWT validation to a message-based authentication protocol after the WebSocket connection is established. This change improves security (by not exposing tokens in URLs), simplifies connection logic, and lays the groundwork for more flexible authentication and error handling. The update includes endpoint changes, new message types and payloads, handler refactoring, and stricter enforcement of authentication for room actions.

**WebSocket Authentication Redesign**

* The WebSocket endpoint now accepts unauthenticated connections and requires clients to send an `authenticate` message (with JWT and room code) within 30 seconds. The server validates this message and only then marks the connection as authenticated. Unauthenticated connections are closed after a timeout. [[1]](diffhunk://#diff-de89eb5617b2658404667f3be9146449842f4d674361fb06d58fcf1247e83a7fL71-R107) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L59-R70) [[3]](diffhunk://#diff-de89eb5617b2658404667f3be9146449842f4d674361fb06d58fcf1247e83a7fR30-R32) [[4]](diffhunk://#diff-de89eb5617b2658404667f3be9146449842f4d674361fb06d58fcf1247e83a7fR221-R235) [[5]](diffhunk://#diff-de89eb5617b2658404667f3be9146449842f4d674361fb06d58fcf1247e83a7fR272-R275)

**Protocol and Schema Updates**

* Added new WebSocket message types (`authenticate`, `authenticated`) and corresponding payload schemas (`AuthenticatePayload`, `AuthenticatedPayload`). A new close code (`AUTH_TIMEOUT`) was introduced for authentication timeouts. [[1]](diffhunk://#diff-cfe7656d66d2513ebf923ff0870b9302f7ccf7b3907f1921455e6c5f60d92752R13-R17) [[2]](diffhunk://#diff-cfe7656d66d2513ebf923ff0870b9302f7ccf7b3907f1921455e6c5f60d92752R46) [[3]](diffhunk://#diff-cfe7656d66d2513ebf923ff0870b9302f7ccf7b3907f1921455e6c5f60d92752R128-R143)

**Handler and Manager Refactoring**

* Introduced a dedicated `authenticate` handler to process authentication messages, validate tokens and room access, and mark connections as authenticated. Connection objects now track their authentication state and user/room association is set only after successful authentication. [[1]](diffhunk://#diff-134a234d9f6029cd74a257a823322e06f53f46eec849a2388708aefe25d38bf8R1-R156) [[2]](diffhunk://#diff-f643ba5d0abcb8449a40f548899749213ce1a0fd4c9ce886d38bbe6a029a5303L30-R41)
* Added a `require_authenticated` utility to enforce authentication in other message handlers (e.g., `leave_room`, `toggle_ready`). These handlers now early-return with an error if the client is not authenticated. [[1]](diffhunk://#diff-9e54a407d8c83dc7155853c45af16e68692fdb272b4504b506d0d08f3d23a806R137-R156) [[2]](diffhunk://#diff-3df3cb134ce09692f6915f51e0ee1b6bf321b33a90b46bc9df9a2e8ab140a4b0L9-R15) [[3]](diffhunk://#diff-3df3cb134ce09692f6915f51e0ee1b6bf321b33a90b46bc9df9a2e8ab140a4b0R27-R31) [[4]](diffhunk://#diff-2fdda163d21179f22b7776502c6106784c943b2db8f12f3d277f7f380753ca99L9-R15) [[5]](diffhunk://#diff-2fdda163d21179f22b7776502c6106784c943b2db8f12f3d277f7f380753ca99R26-R30)

**Documentation and Miscellaneous**

* Updated architecture documentation (`CLAUDE.md`) to reflect the new connection and authentication flow, including the message-based protocol and handler pattern.
* Cleaned up router and handler imports to support the new authentication flow. [[1]](diffhunk://#diff-de89eb5617b2658404667f3be9146449842f4d674361fb06d58fcf1247e83a7fR1-L22) [[2]](diffhunk://#diff-39d9d92dfe345a4313a1f7a5ed6a70c942b1495dad78eeb6a6962f9a81be2624R63) [[3]](diffhunk://#diff-f643ba5d0abcb8449a40f548899749213ce1a0fd4c9ce886d38bbe6a029a5303R15)

These changes make the WebSocket API more secure, robust, and extensible for future features.