### PR TITLE
Establish mid game reconnection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,8 @@ The game engine handles all Ludo Stacked game mechanics:
 
 Related:
 - **`app/services/game/start_game.py`** - Game initialization, creates initial stacks and board setup
-- **`app/services/game/state.py`** - In-memory game state storage (`get_game_state`, `save_game_state`)
+- **`app/services/game/state.py`** - Redis-backed game state storage (`get_game_state`, `save_game_state`, `delete_game_state`), 6-hour TTL
+- **`app/services/game/auto_play.py`** - Auto-play logic for disconnected players (`get_next_auto_action`, `auto_play_turn`)
 
 ### Board Geometry (grid_length = g)
 
@@ -112,6 +113,10 @@ Related:
   - `ws:user:{user_id}:conn_count` - atomic counter for presence tracking
   - `room:{room_id}:meta` - room metadata hash
   - `room:{room_id}:seats` - seat occupancy hash
+  - `room:{room_id}:game_state` - JSON game state, 6-hour TTL
+- **Reconnection Flow**: authenticate → authenticated → game_state (auto-push if room status is `in_game`)
+- **Auto-Move**: After processing an action (or starting a game), if the next player is disconnected, the server waits `TURN_SKIP_GRACE_PERIOD` seconds, then auto-plays their turn. `TurnStarted` events include `auto_played: true` for auto-played turns.
+- **Config**: `TURN_SKIP_GRACE_PERIOD` (default 10s) controls the grace period before auto-playing a disconnected player's turn
 
 See `docs/websockets.md`, `docs/redis.md`, and `docs/db_schema.md` for detailed documentation. Design documents live in `docs/plans/`.
 
@@ -129,7 +134,8 @@ Tests live in `tests/` and cover the game engine and WebSocket handlers. Run wit
 
 - **`conftest.py`** - Shared fixtures: fixed player UUIDs, standard/two-player board setups, helper state builders
 - Engine test files: `test_movement.py`, `test_rolling.py`, `test_captures.py`, `test_validation.py`, `test_stack_utils.py`, `test_stacking.py`, `test_events.py`, `test_game_finished.py`, `test_get_out_of_hell.py`, `test_start_game_handler.py`, `test_board_geometry.py`, `test_homestretch_heaven.py`, `test_hell_exit_collisions.py`, `test_multi_roll_allocation.py`, `test_capture_chains.py`, `test_capture_choice.py`, `test_full_turn_flow.py`
-- WebSocket handler tests: `test_ws_start_game_handler_flow.py`, `test_ws_game_action_handler.py` — unit tests with mocked dependencies
+- WebSocket handler tests: `test_ws_start_game_handler_flow.py`, `test_ws_game_action_handler.py`, `test_ws_game_state_handler.py`, `test_ws_authenticate_reconnect.py` — unit tests with mocked dependencies
+- State/auto-play tests: `test_game_state_redis.py`, `test_auto_play.py`
 - Engine tests construct `GameState` directly and call engine functions; handler tests mock services and validate handler logic
 - All tests currently pass. When new game rules are added, failing tests may be used as the implementation backlog. See `docs/plans/2026-02-28-core-engine-test-suite-design.md` for design details.
 - **Board fixtures use grid_length=6**: `squares_to_win=55`, `squares_to_homestretch=50`, `safe_spaces=[0,7,13,20,26,33,39,46]`

--- a/app/config.py
+++ b/app/config.py
@@ -34,6 +34,7 @@ class Settings(BaseSettings):
     # WebSocket config
     WS_HEARTBEAT_INTERVAL: int = 30
     WS_CONNECTION_TIMEOUT: int = 120
+    TURN_SKIP_GRACE_PERIOD: int = 10  # Seconds before auto-playing disconnected player's turn
 
     @field_validator("UPSTASH_REDIS_REST_URL")
     @classmethod

--- a/app/schemas/game_engine.py
+++ b/app/schemas/game_engine.py
@@ -44,7 +44,9 @@ class GameSettings(BaseModel):
 # Defined at game start
 class BoardSetup(BaseModel):
     grid_length: int
-    loop_length: int = Field(..., description="Total number of squares in one loop around the board")
+    loop_length: int = Field(
+        ..., description="Total number of squares in one loop around the board"
+    )
     squares_to_win: int
     squares_to_homestretch: int
     starting_positions: list[int]
@@ -66,6 +68,7 @@ class LegalMoveGroup(BaseModel):
 
 class RollMoveGroup(BaseModel):
     """Legal moves available for a specific roll value."""
+
     roll: int
     move_groups: list[LegalMoveGroup]
 
@@ -78,6 +81,7 @@ class Player(PlayerAttributes):
 
 class PendingCapture(BaseModel):
     """Context stored when a move triggers a multi-target capture choice."""
+
     moving_stack_id: str
     position: int
     capturable_targets: list[str]  # "{player_id}:{stack_id}" format

--- a/app/schemas/ws.py
+++ b/app/schemas/ws.py
@@ -156,9 +156,7 @@ class GameEventsPayload(BaseModel):
     Events are broadcast to all room members for animation/UI updates.
     """
 
-    events: list[dict[str, Any]] = Field(
-        ..., description="List of game events (serialized)"
-    )
+    events: list[dict[str, Any]] = Field(..., description="List of game events (serialized)")
 
 
 class GameStartedPayload(BaseModel):

--- a/app/schemas/ws.py
+++ b/app/schemas/ws.py
@@ -171,3 +171,12 @@ class GameStartedPayload(BaseModel):
     events: list[dict[str, Any]] = Field(
         ..., description="List of game events (game_started, turn_started)"
     )
+
+
+class GameStatePayload(BaseModel):
+    """Payload for GAME_STATE message to client.
+
+    Contains the full game state for reconnection sync.
+    """
+
+    game_state: dict[str, Any] = Field(..., description="Full game state (serialized)")

--- a/app/services/game/auto_play.py
+++ b/app/services/game/auto_play.py
@@ -1,0 +1,106 @@
+"""Auto-play logic for disconnected players.
+
+Generates actions deterministically (first available move) and feeds them
+through the normal engine pipeline. The engine stays untouched — this module
+is just a caller that produces actions on behalf of a disconnected player.
+"""
+
+import logging
+import random
+
+from app.schemas.game_engine import CurrentEvent, GameState
+from app.services.game.engine.actions import (
+    CaptureChoiceAction,
+    GameAction,
+    MoveAction,
+    RollAction,
+)
+from app.services.game.engine.events import AnyGameEvent
+from app.services.game.engine.legal_moves import get_all_roll_move_groups
+from app.services.game.engine.process import process_action
+
+logger = logging.getLogger(__name__)
+
+
+def get_next_auto_action(state: GameState, player_id) -> GameAction:
+    """Inspect current game state and return the appropriate action.
+
+    Selection strategy: always pick the first available option.
+    - PLAYER_ROLL: random dice roll (1-6)
+    - PLAYER_CHOICE: first RollMoveGroup -> first LegalMoveGroup -> first move ID
+    - CAPTURE_CHOICE: first entry in pending_capture.capturable_targets
+    """
+    current_event = state.current_event
+    turn = state.current_turn
+
+    if current_event == CurrentEvent.PLAYER_ROLL:
+        return RollAction(value=random.randint(1, 6))
+
+    if current_event == CurrentEvent.PLAYER_CHOICE:
+        player = next(p for p in state.players if p.player_id == player_id)
+        roll_move_groups = get_all_roll_move_groups(
+            player, turn.rolls_to_allocate, state.board_setup
+        )
+        # Pick first roll group -> first move group -> first move ID
+        first_group = roll_move_groups[0]
+        first_move_group = first_group.move_groups[0]
+        first_move_id = first_move_group.moves[0]
+        return MoveAction(stack_id=first_move_id, roll_value=first_group.roll)
+
+    if current_event == CurrentEvent.CAPTURE_CHOICE:
+        first_target = turn.pending_capture.capturable_targets[0]
+        return CaptureChoiceAction(choice=first_target)
+
+    msg = f"Unexpected current_event for auto-play: {current_event}"
+    raise ValueError(msg)
+
+
+def auto_play_turn(
+    state: GameState,
+    player_id,
+) -> tuple[GameState, list[AnyGameEvent]]:
+    """Auto-play a full turn for a disconnected player.
+
+    Loops calling get_next_auto_action -> process_action until the turn
+    transitions to a different player or the game ends.
+
+    Returns:
+        Tuple of (final_state, all_events_accumulated).
+    """
+    all_events: list[AnyGameEvent] = []
+    current_state = state
+
+    # Safety bound: a turn can have at most ~20 actions
+    # (3 rolls max before penalty + moves + captures + extra rolls)
+    max_iterations = 50
+
+    for _ in range(max_iterations):
+        # Check if turn has transitioned away from this player
+        if current_state.current_turn is None:
+            break
+        if current_state.current_turn.player_id != player_id:
+            break
+        if current_state.phase.value == "finished":
+            break
+
+        action = get_next_auto_action(current_state, player_id)
+        result = process_action(current_state, action, player_id)
+
+        if not result.success:
+            logger.error(
+                "Auto-play action failed: %s — %s",
+                result.error_code,
+                result.error_message,
+            )
+            break
+
+        all_events.extend(result.events)
+        current_state = result.state
+
+    logger.info(
+        "Auto-played turn for player=%s: %d events",
+        str(player_id)[:8],
+        len(all_events),
+    )
+
+    return current_state, all_events

--- a/app/services/game/engine/events.py
+++ b/app/services/game/engine/events.py
@@ -109,6 +109,7 @@ class TurnStarted(GameEvent):
     event_type: Literal["turn_started"] = "turn_started"
     player_id: UUID
     turn_number: int
+    auto_played: bool = False
 
 
 class RollGranted(GameEvent):

--- a/app/services/game/engine/movement.py
+++ b/app/services/game/engine/movement.py
@@ -23,7 +23,13 @@ from app.schemas.game_engine import (
     Turn,
 )
 
-from .captures import detect_collisions, get_absolute_position, resolve_capture, resolve_collision, resolve_stacking
+from .captures import (
+    detect_collisions,
+    get_absolute_position,
+    resolve_capture,
+    resolve_collision,
+    resolve_stacking,
+)
 from .events import (
     AnyGameEvent,
     AwaitingCaptureChoice,
@@ -883,7 +889,8 @@ def handle_homestretch_stacking(
             # Update moved_piece to the newly merged stack for the next iteration
             updated_player = next(p for p in state.players if p.player_id == player.player_id)
             moved_piece = next(
-                s for s in updated_player.stacks
+                s
+                for s in updated_player.stacks
                 if s.progress == moved_piece.progress and s.state == StackState.HOMESTRETCH
             )
             merged = True
@@ -918,7 +925,5 @@ def _check_and_handle_win(
             final_rankings=[winner_id],
         )
     )
-    new_state = state.model_copy(
-        update={"phase": GamePhase.FINISHED}
-    )
+    new_state = state.model_copy(update={"phase": GamePhase.FINISHED})
     return ProcessResult.ok(new_state, events)

--- a/app/services/game/state.py
+++ b/app/services/game/state.py
@@ -1,17 +1,54 @@
-"""Game state storage.
+"""Game state storage backed by Redis.
 
-TODO: Replace with Redis-based game service.
+Stores serialized GameState dicts in Redis with a 6-hour TTL.
+Key pattern: room:{room_id}:game_state
 """
 
-# Placeholder for game state storage - will be replaced with Redis service
-_game_states: dict[str, dict] = {}
+import json
+import logging
+
+from app.dependencies.redis import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+GAME_STATE_TTL = 21600  # 6 hours in seconds
+
+
+def _key(room_id: str) -> str:
+    return f"room:{room_id}:game_state"
 
 
 async def get_game_state(room_id: str) -> dict | None:
-    """Get game state for a room from storage."""
-    return _game_states.get(room_id)
+    """Get game state for a room from Redis.
+
+    Returns None if not found or on Redis error.
+    """
+    try:
+        redis = get_redis_client()
+        data = await redis.get(_key(room_id))
+        if data is None:
+            return None
+        return json.loads(data)
+    except Exception:
+        logger.exception("Failed to get game state for room %s", room_id)
+        return None
 
 
 async def save_game_state(room_id: str, state: dict) -> None:
-    """Save game state for a room to storage."""
-    _game_states[room_id] = state
+    """Save game state for a room to Redis with TTL.
+
+    Raises on Redis error so callers can handle write failures.
+    """
+    redis = get_redis_client()
+    await redis.set(_key(room_id), json.dumps(state), ex=GAME_STATE_TTL)
+    logger.debug("Game state saved for room %s", room_id)
+
+
+async def delete_game_state(room_id: str) -> None:
+    """Delete game state for a room from Redis."""
+    try:
+        redis = get_redis_client()
+        await redis.delete(_key(room_id))
+        logger.debug("Game state deleted for room %s", room_id)
+    except Exception:
+        logger.exception("Failed to delete game state for room %s", room_id)

--- a/app/services/room/service.py
+++ b/app/services/room/service.py
@@ -730,7 +730,7 @@ class RoomService:
 
     async def _update_seat_in_db(self, room_id: str, seat_index: int, user_id: str | None) -> bool:
         """Update a seat in the database.
-        
+
         If user_id is None, clears the seat (for rollback).
         Otherwise, assigns the seat to the user (optimistic lock).
         """
@@ -1208,9 +1208,7 @@ class RoomService:
             )
 
             if not response.data or len(response.data) == 0:
-                logger.warning(
-                    "Room %s not found in DB when updating to in_game", room_id
-                )
+                logger.warning("Room %s not found in DB when updating to in_game", room_id)
                 return False
 
             # Increment room version
@@ -1220,9 +1218,7 @@ class RoomService:
             return True
 
         except Exception as e:
-            logger.exception(
-                "Error updating room %s status to in_game: %s", room_id, e
-            )
+            logger.exception("Error updating room %s status to in_game: %s", room_id, e)
             return False
 
     async def leave_room(self, room_id: str, user_id: str) -> LeaveRoomResult:

--- a/app/services/websocket/handlers/__init__.py
+++ b/app/services/websocket/handlers/__init__.py
@@ -63,6 +63,7 @@ async def dispatch(ctx: HandlerContext) -> HandlerResult | None:
 from . import (
     authenticate,  # noqa: E402, F401
     game,  # noqa: E402, F401
+    game_state,  # noqa: E402, F401
     leave,  # noqa: E402, F401
     ping,  # noqa: E402, F401
     ready,  # noqa: E402, F401

--- a/app/services/websocket/handlers/authenticate.py
+++ b/app/services/websocket/handlers/authenticate.py
@@ -4,9 +4,11 @@ import logging
 
 from app.schemas.ws import (
     AuthenticatePayload,
+    GameStatePayload,
     MessageType,
     WSServerMessage,
 )
+from app.services.game.state import get_game_state
 from app.services.room.service import get_room_service
 from app.services.websocket.auth import get_ws_authenticator
 
@@ -143,6 +145,26 @@ async def handle_authenticate(ctx: HandlerContext) -> HandlerResult:
         user_id,
         payload.room_code,
     )
+
+    # Auto-push game state if room has an active game
+    room_status = room_snapshot_data.status if hasattr(room_snapshot_data, "status") else None
+    if room_status == "in_game":
+        game_state_dict = await get_game_state(room_id)
+        if game_state_dict is not None:
+            await ctx.manager.send_to_connection(
+                ctx.connection_id,
+                WSServerMessage(
+                    type=MessageType.GAME_STATE,
+                    payload=GameStatePayload(
+                        game_state=game_state_dict,
+                    ).model_dump(),
+                ),
+            )
+            logger.info(
+                "Auto-pushed game state to reconnecting user %s in room %s",
+                user_id[:8],
+                room_id,
+            )
 
     # Broadcast room update to other members
     return HandlerResult(

--- a/app/services/websocket/handlers/game.py
+++ b/app/services/websocket/handlers/game.py
@@ -222,8 +222,7 @@ async def _auto_play_disconnected_turns(
             break
 
         player_connected = any(
-            seat.user_id == current_player_id and seat.connected
-            for seat in snapshot.seats
+            seat.user_id == current_player_id and seat.connected for seat in snapshot.seats
         )
 
         if player_connected:
@@ -239,8 +238,7 @@ async def _auto_play_disconnected_turns(
             break
 
         player_connected = any(
-            seat.user_id == current_player_id and seat.connected
-            for seat in snapshot.seats
+            seat.user_id == current_player_id and seat.connected for seat in snapshot.seats
         )
 
         if player_connected:

--- a/app/services/websocket/handlers/game.py
+++ b/app/services/websocket/handlers/game.py
@@ -146,10 +146,10 @@ async def handle_game_action(ctx: HandlerContext) -> HandlerResult:
 
     # Save new state
     if result.state is not None:
-        await save_game_state(room_id, result.state.model_dump())
+        await save_game_state(room_id, result.state.model_dump(mode="json"))
 
     # Serialize events for broadcast
-    serialized_events = [event.model_dump() for event in result.events]
+    serialized_events = [event.model_dump(mode="json") for event in result.events]
 
     logger.info(
         "Game action processed for user %s in room %s: %d events",
@@ -250,14 +250,14 @@ async def _auto_play_disconnected_turns(
         # Set auto_played flag on TurnStarted events
         event_dicts = []
         for event in events:
-            d = event.model_dump()
+            d = event.model_dump(mode="json")
             if event.event_type == "turn_started":
                 d["auto_played"] = True
             event_dicts.append(d)
         all_auto_events.extend(event_dicts)
 
         # Save updated state
-        await save_game_state(room_id, state.model_dump())
+        await save_game_state(room_id, state.model_dump(mode="json"))
 
         logger.info(
             "Auto-played disconnected player %s turn in room %s",

--- a/app/services/websocket/handlers/game.py
+++ b/app/services/websocket/handlers/game.py
@@ -1,8 +1,10 @@
 """Handler for GAME_ACTION messages."""
 
+import asyncio
 import logging
 from uuid import UUID
 
+from app.config import get_settings
 from app.schemas.game_engine import GameState
 from app.schemas.ws import (
     GameActionPayload,
@@ -11,7 +13,9 @@ from app.schemas.ws import (
     WSServerMessage,
 )
 from app.services.game import ProcessResult, build_action_from_payload, process_action
+from app.services.game.auto_play import auto_play_turn
 from app.services.game.state import get_game_state, save_game_state
+from app.services.room.service import get_room_service
 
 from . import handler
 from .base import (
@@ -154,17 +158,113 @@ async def handle_game_action(ctx: HandlerContext) -> HandlerResult:
         len(result.events),
     )
 
-    # Return events to requester and broadcast to room
+    # Build initial response and broadcast
+    response = WSServerMessage(
+        type=MessageType.GAME_EVENTS,
+        request_id=ctx.message.request_id,
+        payload=GameEventsPayload(events=serialized_events).model_dump(),
+    )
+    broadcast = WSServerMessage(
+        type=MessageType.GAME_EVENTS,
+        payload=GameEventsPayload(events=serialized_events).model_dump(),
+    )
+
+    # Check for disconnected player auto-move
+    if result.state is not None and result.state.phase.value == "in_progress":
+        auto_events = await _auto_play_disconnected_turns(room_id, result.state, ctx)
+        if auto_events:
+            # Append auto-play events to the broadcast
+            all_events = serialized_events + auto_events
+            broadcast = WSServerMessage(
+                type=MessageType.GAME_EVENTS,
+                payload=GameEventsPayload(events=all_events).model_dump(),
+            )
+            response = WSServerMessage(
+                type=MessageType.GAME_EVENTS,
+                request_id=ctx.message.request_id,
+                payload=GameEventsPayload(events=all_events).model_dump(),
+            )
+
     return HandlerResult(
         success=True,
-        response=WSServerMessage(
-            type=MessageType.GAME_EVENTS,
-            request_id=ctx.message.request_id,
-            payload=GameEventsPayload(events=serialized_events).model_dump(),
-        ),
-        broadcast=WSServerMessage(
-            type=MessageType.GAME_EVENTS,
-            payload=GameEventsPayload(events=serialized_events).model_dump(),
-        ),
+        response=response,
+        broadcast=broadcast,
         room_id=room_id,
     )
+
+
+async def _auto_play_disconnected_turns(
+    room_id: str,
+    current_state: "GameState",
+    ctx: HandlerContext,
+) -> list[dict]:
+    """Check if current player is disconnected and auto-play their turn after grace period.
+
+    Returns list of serialized auto-play events (empty if no auto-play needed).
+    Handles consecutive disconnected players.
+    """
+    all_auto_events: list[dict] = []
+    state = current_state
+    max_auto_plays = len(state.players)  # Safety: don't auto-play more than full rotation
+
+    for _ in range(max_auto_plays):
+        if state.current_turn is None:
+            break
+        if state.phase.value == "finished":
+            break
+
+        current_player_id = str(state.current_turn.player_id)
+
+        # Check if current player is connected
+        room_service = get_room_service()
+        snapshot = await room_service.get_room_snapshot(room_id)
+        if snapshot is None:
+            break
+
+        player_connected = any(
+            seat.user_id == current_player_id and seat.connected
+            for seat in snapshot.seats
+        )
+
+        if player_connected:
+            break
+
+        # Grace period
+        settings = get_settings()
+        await asyncio.sleep(settings.TURN_SKIP_GRACE_PERIOD)
+
+        # Re-check after grace period
+        snapshot = await room_service.get_room_snapshot(room_id)
+        if snapshot is None:
+            break
+
+        player_connected = any(
+            seat.user_id == current_player_id and seat.connected
+            for seat in snapshot.seats
+        )
+
+        if player_connected:
+            break
+
+        # Auto-play this player's turn
+        state, events = auto_play_turn(state, current_player_id)
+
+        # Set auto_played flag on TurnStarted events
+        event_dicts = []
+        for event in events:
+            d = event.model_dump()
+            if event.event_type == "turn_started":
+                d["auto_played"] = True
+            event_dicts.append(d)
+        all_auto_events.extend(event_dicts)
+
+        # Save updated state
+        await save_game_state(room_id, state.model_dump())
+
+        logger.info(
+            "Auto-played disconnected player %s turn in room %s",
+            current_player_id[:8],
+            room_id,
+        )
+
+    return all_auto_events

--- a/app/services/websocket/handlers/game.py
+++ b/app/services/websocket/handlers/game.py
@@ -171,8 +171,17 @@ async def handle_game_action(ctx: HandlerContext) -> HandlerResult:
 
     # Check for disconnected player auto-move
     if result.state is not None and result.state.phase.value == "in_progress":
-        auto_events = await _auto_play_disconnected_turns(room_id, result.state, ctx)
+        auto_events, auto_played_ids = await _auto_play_disconnected_turns(
+            room_id, result.state, ctx
+        )
         if auto_events:
+            # Mark TurnStarted in original events for auto-played players
+            for d in serialized_events:
+                if (
+                    d.get("event_type") == "turn_started"
+                    and d.get("player_id") in auto_played_ids
+                ):
+                    d["auto_played"] = True
             # Append auto-play events to the broadcast
             all_events = serialized_events + auto_events
             broadcast = WSServerMessage(
@@ -197,13 +206,14 @@ async def _auto_play_disconnected_turns(
     room_id: str,
     current_state: "GameState",
     ctx: HandlerContext,
-) -> list[dict]:
+) -> tuple[list[dict], set[str]]:
     """Check if current player is disconnected and auto-play their turn after grace period.
 
-    Returns list of serialized auto-play events (empty if no auto-play needed).
+    Returns tuple of (serialized auto-play events, set of auto-played player ID strings).
     Handles consecutive disconnected players.
     """
     all_auto_events: list[dict] = []
+    auto_played_ids: set[str] = set()
     state = current_state
     max_auto_plays = len(state.players)  # Safety: don't auto-play more than full rotation
 
@@ -213,7 +223,8 @@ async def _auto_play_disconnected_turns(
         if state.phase.value == "finished":
             break
 
-        current_player_id = str(state.current_turn.player_id)
+        current_player_id = state.current_turn.player_id
+        current_player_id_str = str(current_player_id)
 
         # Check if current player is connected
         room_service = get_room_service()
@@ -222,7 +233,8 @@ async def _auto_play_disconnected_turns(
             break
 
         player_connected = any(
-            seat.user_id == current_player_id and seat.connected for seat in snapshot.seats
+            seat.user_id == current_player_id_str and seat.connected
+            for seat in snapshot.seats
         )
 
         if player_connected:
@@ -238,22 +250,19 @@ async def _auto_play_disconnected_turns(
             break
 
         player_connected = any(
-            seat.user_id == current_player_id and seat.connected for seat in snapshot.seats
+            seat.user_id == current_player_id_str and seat.connected
+            for seat in snapshot.seats
         )
 
         if player_connected:
             break
 
+        auto_played_ids.add(current_player_id_str)
+
         # Auto-play this player's turn
         state, events = auto_play_turn(state, current_player_id)
 
-        # Set auto_played flag on TurnStarted events
-        event_dicts = []
-        for event in events:
-            d = event.model_dump(mode="json")
-            if event.event_type == "turn_started":
-                d["auto_played"] = True
-            event_dicts.append(d)
+        event_dicts = [event.model_dump(mode="json") for event in events]
         all_auto_events.extend(event_dicts)
 
         # Save updated state
@@ -261,8 +270,16 @@ async def _auto_play_disconnected_turns(
 
         logger.info(
             "Auto-played disconnected player %s turn in room %s",
-            current_player_id[:8],
+            current_player_id_str[:8],
             room_id,
         )
 
-    return all_auto_events
+    # Mark TurnStarted events only for players who were actually auto-played
+    for d in all_auto_events:
+        if (
+            d.get("event_type") == "turn_started"
+            and d.get("player_id") in auto_played_ids
+        ):
+            d["auto_played"] = True
+
+    return all_auto_events, auto_played_ids

--- a/app/services/websocket/handlers/game_state.py
+++ b/app/services/websocket/handlers/game_state.py
@@ -1,0 +1,61 @@
+"""Handler for GAME_STATE request messages."""
+
+import logging
+
+from app.schemas.ws import (
+    GameStatePayload,
+    MessageType,
+    WSServerMessage,
+)
+from app.services.game.state import get_game_state
+
+from . import handler
+from .base import (
+    HandlerContext,
+    HandlerResult,
+    error_response,
+    require_authenticated,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@handler(MessageType.GAME_STATE)
+async def handle_game_state(ctx: HandlerContext) -> HandlerResult:
+    """Handle GAME_STATE request — return full game state for reconnection sync.
+
+    Client sends: { type: "game_state", request_id: "..." }
+    Server sends: { type: "game_state", request_id: "...", payload: { game_state: {...} } }
+    """
+    auth_error = require_authenticated(ctx)
+    if auth_error:
+        return auth_error
+
+    connection = ctx.manager.get_connection(ctx.connection_id)
+    if connection is None or connection.room_id is None:
+        return error_response(
+            error_code="NOT_IN_ROOM",
+            message="You are not in a room",
+            error_type=MessageType.GAME_ERROR,
+            request_id=ctx.message.request_id,
+        )
+
+    game_state_dict = await get_game_state(connection.room_id)
+    if game_state_dict is None:
+        return error_response(
+            error_code="GAME_NOT_FOUND",
+            message="No game in progress for this room",
+            error_type=MessageType.GAME_ERROR,
+            request_id=ctx.message.request_id,
+        )
+
+    return HandlerResult(
+        success=True,
+        response=WSServerMessage(
+            type=MessageType.GAME_STATE,
+            request_id=ctx.message.request_id,
+            payload=GameStatePayload(
+                game_state=game_state_dict,
+            ).model_dump(),
+        ),
+    )

--- a/app/services/websocket/handlers/start_game.py
+++ b/app/services/websocket/handlers/start_game.py
@@ -263,6 +263,7 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
 
     # Check if first player is disconnected and needs auto-play
     auto_event_dicts: list[dict] = []
+    auto_played_ids: set[str] = set()
     max_auto_plays = len(current_state.players)
 
     for _ in range(max_auto_plays):
@@ -271,9 +272,11 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
         if current_state.phase.value == "finished":
             break
 
-        current_player_id = str(current_state.current_turn.player_id)
+        current_player_id = current_state.current_turn.player_id
+        current_player_id_str = str(current_player_id)
         player_connected = any(
-            seat.user_id == current_player_id and seat.connected for seat in room_snapshot.seats
+            seat.user_id == current_player_id_str and seat.connected
+            for seat in room_snapshot.seats
         )
 
         if player_connected:
@@ -288,22 +291,35 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
             break
 
         player_connected = any(
-            seat.user_id == current_player_id and seat.connected for seat in fresh_snapshot.seats
+            seat.user_id == current_player_id_str and seat.connected
+            for seat in fresh_snapshot.seats
         )
 
         if player_connected:
             break
 
+        auto_played_ids.add(current_player_id_str)
+
         current_state, auto_events = auto_play_turn(current_state, current_player_id)
 
-        # Set auto_played flag on TurnStarted events
         for event in auto_events:
-            d = event.model_dump(mode="json")
-            if event.event_type == "turn_started":
-                d["auto_played"] = True
-            auto_event_dicts.append(d)
+            auto_event_dicts.append(event.model_dump(mode="json"))
 
         await save_game_state(room_id, current_state.model_dump(mode="json"))
+
+    # Mark TurnStarted events only for players who were actually auto-played
+    for d in auto_event_dicts:
+        if (
+            d.get("event_type") == "turn_started"
+            and d.get("player_id") in auto_played_ids
+        ):
+            d["auto_played"] = True
+    for d in serialized_events:
+        if (
+            d.get("event_type") == "turn_started"
+            and d.get("player_id") in auto_played_ids
+        ):
+            d["auto_played"] = True
 
     all_events = serialized_events + auto_event_dicts
     serialized_state = current_state.model_dump(mode="json")

--- a/app/services/websocket/handlers/start_game.py
+++ b/app/services/websocket/handlers/start_game.py
@@ -273,8 +273,7 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
 
         current_player_id = str(current_state.current_turn.player_id)
         player_connected = any(
-            seat.user_id == current_player_id and seat.connected
-            for seat in room_snapshot.seats
+            seat.user_id == current_player_id and seat.connected for seat in room_snapshot.seats
         )
 
         if player_connected:
@@ -289,8 +288,7 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
             break
 
         player_connected = any(
-            seat.user_id == current_player_id and seat.connected
-            for seat in fresh_snapshot.seats
+            seat.user_id == current_player_id and seat.connected for seat in fresh_snapshot.seats
         )
 
         if player_connected:

--- a/app/services/websocket/handlers/start_game.py
+++ b/app/services/websocket/handlers/start_game.py
@@ -1,8 +1,10 @@
 """Handler for START_GAME messages."""
 
+import asyncio
 import logging
 from uuid import UUID
 
+from app.config import get_settings
 from app.schemas.game_engine import GameSettings, PlayerAttributes
 from app.schemas.ws import (
     GameSettingsPayload,
@@ -11,6 +13,7 @@ from app.schemas.ws import (
     WSServerMessage,
 )
 from app.services.game import StartGameAction, initialize_game, process_action
+from app.services.game.auto_play import auto_play_turn
 from app.services.game.state import get_game_state, save_game_state
 from app.services.room.service import RoomSnapshotData, get_room_service
 
@@ -256,14 +259,63 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
 
     # Serialize events and state for broadcast
     serialized_events = [event.model_dump() for event in result.events]
-    serialized_state = result.state.model_dump()
+    current_state = result.state
+
+    # Check if first player is disconnected and needs auto-play
+    auto_event_dicts: list[dict] = []
+    max_auto_plays = len(current_state.players)
+
+    for _ in range(max_auto_plays):
+        if current_state.current_turn is None:
+            break
+        if current_state.phase.value == "finished":
+            break
+
+        current_player_id = str(current_state.current_turn.player_id)
+        player_connected = any(
+            seat.user_id == current_player_id and seat.connected
+            for seat in room_snapshot.seats
+        )
+
+        if player_connected:
+            break
+
+        settings = get_settings()
+        await asyncio.sleep(settings.TURN_SKIP_GRACE_PERIOD)
+
+        # Re-check from Redis
+        fresh_snapshot = await room_service.get_room_snapshot(room_id)
+        if fresh_snapshot is None:
+            break
+
+        player_connected = any(
+            seat.user_id == current_player_id and seat.connected
+            for seat in fresh_snapshot.seats
+        )
+
+        if player_connected:
+            break
+
+        current_state, auto_events = auto_play_turn(current_state, current_player_id)
+
+        # Set auto_played flag on TurnStarted events
+        for event in auto_events:
+            d = event.model_dump()
+            if event.event_type == "turn_started":
+                d["auto_played"] = True
+            auto_event_dicts.append(d)
+
+        await save_game_state(room_id, current_state.model_dump())
+
+    all_events = serialized_events + auto_event_dicts
+    serialized_state = current_state.model_dump()
 
     logger.info(
         "Game started for room %s by host %s: %d events, %d players",
         room_id,
         ctx.user_id,
-        len(result.events),
-        len(result.state.players),
+        len(all_events),
+        len(current_state.players),
     )
 
     # Broadcast GAME_STARTED with full state to ALL players so they can render UI
@@ -275,14 +327,14 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
             request_id=ctx.message.request_id,
             payload=GameStartedPayload(
                 game_state=serialized_state,
-                events=serialized_events,
+                events=all_events,
             ).model_dump(),
         ),
         broadcast=WSServerMessage(
             type=MessageType.GAME_STARTED,
             payload=GameStartedPayload(
                 game_state=serialized_state,
-                events=serialized_events,
+                events=all_events,
             ).model_dump(),
         ),
         room_id=room_id,

--- a/app/services/websocket/handlers/start_game.py
+++ b/app/services/websocket/handlers/start_game.py
@@ -252,13 +252,13 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
         )
 
     # Save game state
-    await save_game_state(room_id, result.state.model_dump())
+    await save_game_state(room_id, result.state.model_dump(mode="json"))
 
     # Update room status to in_game
     await room_service.update_room_status_to_in_game(room_id)
 
     # Serialize events and state for broadcast
-    serialized_events = [event.model_dump() for event in result.events]
+    serialized_events = [event.model_dump(mode="json") for event in result.events]
     current_state = result.state
 
     # Check if first player is disconnected and needs auto-play
@@ -298,15 +298,15 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
 
         # Set auto_played flag on TurnStarted events
         for event in auto_events:
-            d = event.model_dump()
+            d = event.model_dump(mode="json")
             if event.event_type == "turn_started":
                 d["auto_played"] = True
             auto_event_dicts.append(d)
 
-        await save_game_state(room_id, current_state.model_dump())
+        await save_game_state(room_id, current_state.model_dump(mode="json"))
 
     all_events = serialized_events + auto_event_dicts
-    serialized_state = current_state.model_dump()
+    serialized_state = current_state.model_dump(mode="json")
 
     logger.info(
         "Game started for room %s by host %s: %d events, %d players",

--- a/app/services/websocket/manager.py
+++ b/app/services/websocket/manager.py
@@ -150,7 +150,9 @@ class ConnectionManager:
             await self._redis.incr(self._redis_user_conn_count_key(user_id))
         except Exception as e:
             logger.error(
-                "Failed to increment connection count for user %s in Redis: %s", user_id[:8] if user_id else "unknown", e
+                "Failed to increment connection count for user %s in Redis: %s",
+                user_id[:8] if user_id else "unknown",
+                e,
             )
 
         logger.info(
@@ -244,10 +246,16 @@ class ConnectionManager:
                 await self._redis.delete(self._redis_user_conn_count_key(user_id))
         except Exception as e:
             logger.error(
-                "Failed to decrement connection count for user %s in Redis: %s", user_id[:8] if user_id else "unknown", e
+                "Failed to decrement connection count for user %s in Redis: %s",
+                user_id[:8] if user_id else "unknown",
+                e,
             )
 
-        logger.info("Connection %s disconnected for user %s", connection_id, user_id[:8] if user_id else "unknown")
+        logger.info(
+            "Connection %s disconnected for user %s",
+            connection_id,
+            user_id[:8] if user_id else "unknown",
+        )
 
     async def heartbeat(self, connection_id: str) -> None:
         """Update the last heartbeat timestamp for a connection.

--- a/docs/superpowers/specs/2026-03-21-auto-move-design.md
+++ b/docs/superpowers/specs/2026-03-21-auto-move-design.md
@@ -1,0 +1,110 @@
+# Auto-Move: Skip Player Choice When Only One Legal Move Exists
+
+**Date:** 2026-03-21
+**Status:** Draft
+
+## Problem
+
+When a player has only one possible move after rolling, the game still emits `AwaitingChoice` and waits for a `MoveAction` from the client. This adds unnecessary round-trips and delays gameplay for situations where the player has no real decision to make.
+
+## Solution
+
+Extract a shared helper function that replaces the current "compute moves → emit AwaitingChoice" pattern. When exactly one legal move exists, the engine auto-executes it immediately, emitting all normal movement events. When multiple options exist, behavior is unchanged.
+
+## Trigger Condition
+
+Auto-move fires when ALL of the following are true:
+- `get_all_roll_move_groups` returns exactly **1** `RollMoveGroup`
+- That group contains exactly **1** `LegalMoveGroup`
+- That group contains exactly **1** move ID
+
+Any additional options (multiple rolls with moves, multiple stacks, split options) prevent auto-move.
+
+## Design
+
+### Shared Helper
+
+New function in `movement.py`:
+
+```python
+def resolve_moves_or_await(
+    state: GameState,
+    player: Player,
+    rolls: list[int],
+    events: list[AnyGameEvent],
+) -> ProcessResult | None
+```
+
+Logic:
+1. Compute `roll_move_groups` via `get_all_roll_move_groups(player, rolls, board_setup)`
+2. If no legal moves: return `None` (caller handles turn end / extra rolls)
+3. If exactly one option (1 RollMoveGroup, 1 LegalMoveGroup, 1 move ID): call `process_move(state, stack_id, roll_value, player_id)` directly, prepend the caller's events, return the result
+4. If multiple options: emit `AwaitingChoice`, update turn with legal moves, set state to `PLAYER_CHOICE`, return result
+
+### Call Sites
+
+Three locations replace their current "compute moves → emit AwaitingChoice" blocks with a call to `resolve_moves_or_await`:
+
+1. **`rolling.py:process_roll`** (lines ~171-201) — after a non-6 roll
+2. **`movement.py:process_after_move`** (lines ~526-558) — after consuming a roll, checking remaining rolls
+3. **`movement.py:resume_after_capture`** (lines ~664-691) — after capture choice resolution
+
+Each caller: if `resolve_moves_or_await` returns a `ProcessResult`, return it. If `None`, fall through to existing "no legal moves" logic (turn end, extra rolls, etc.).
+
+### Recursion
+
+When auto-move fires, `process_move` is called, which internally calls `process_after_move`, which calls `resolve_moves_or_await` again. This creates natural chaining: if the remaining rolls also have exactly one option, they auto-execute too.
+
+The recursion is bounded because:
+- Each auto-move consumes one roll from `rolls_to_allocate` (finite list)
+- Extra rolls (capture bonus, heaven bonus) transition state to `PLAYER_ROLL`, requiring a `RollAction` from the player
+- Turn end terminates the chain
+- Maximum recursion depth is bounded by the number of rolls per turn (at most ~6 in extreme cases), well within Python's stack limit
+
+### Auto-Move Failure
+
+An auto-move failure (e.g., `process_move` returning an error) is a logic error — the engine selected a move from its own computed legal moves. If this happens, propagate the failure `ProcessResult` as-is. This surfaces bugs rather than silently masking them.
+
+### Interaction with Capture Choice
+
+If an auto-executed move causes a collision with multiple capturable opponents, `process_move` returns state in `CAPTURE_CHOICE`. The auto-move chain pauses. The player must send a `CaptureChoiceAction`. After resolution, `resume_after_capture` may trigger further auto-moves via the same helper.
+
+### Events
+
+Auto-move emits the same events as a manual move. No new event types. No `AwaitingChoice` is emitted when auto-move fires.
+
+Examples:
+- **Road move:** `DiceRolled → StackMoved → TurnEnded → TurnStarted → RollGranted`
+- **Hell exit:** `DiceRolled → StackExitedHell → TurnEnded → TurnStarted → RollGranted`
+- **Auto-move + capture:** `DiceRolled → StackMoved → StackCaptured → RollGranted`
+- **Chained auto-moves:** `DiceRolled → StackMoved → StackMoved → TurnEnded → TurnStarted → RollGranted`
+
+### Out of Scope
+
+- `AwaitingCaptureChoice` — not affected by auto-move
+- Rolling — player always sends `RollAction`
+- New event types — not needed
+
+## Files Changed
+
+- `app/services/game/engine/movement.py` — add `resolve_moves_or_await`, update `process_after_move` and `resume_after_capture`
+- `app/services/game/engine/rolling.py` — update `process_roll` to use `resolve_moves_or_await`
+- `tests/test_auto_move.py` — new test file
+
+## Tests
+
+New test file `tests/test_auto_move.py`:
+
+1. **Single move auto-executes** — one stack on ROAD, roll produces one legal move → `StackMoved` emitted, no `AwaitingChoice`
+2. **Multiple moves emit AwaitingChoice** — two stacks on ROAD, roll has moves for both → `AwaitingChoice` emitted (regression)
+3. **Split option prevents auto-move** — height-2 stack, roll divisible by both 1 and 2 → `AwaitingChoice` emitted
+4. **Auto-move chains across remaining rolls** — rolls [3, 5], each with one move → both auto-execute
+5. **Auto-move from resume_after_capture** — after capture resolution, remaining rolls have one option → auto-executes
+6. **Hell exit auto-move** — only stack in HELL, roll is 6 → `StackExitedHell` emitted, no `AwaitingChoice`
+7. **Auto-move triggers capture with bonus roll** — single stack, move lands on single capturable opponent → auto-move fires, capture auto-resolves, extra roll granted, state transitions to `PLAYER_ROLL`
+8. **Auto-move reaches heaven with bonus rolls** — only legal move sends stack to HEAVEN → auto-move fires, `StackReachedHeaven` emitted, `heaven_extra_rolls` granted, state transitions to `PLAYER_ROLL`
+9. **Height-2 stack with only full-stack move legal** — split would overshoot `squares_to_win`, only full-stack move valid → auto-move fires
+
+## Existing Test Migration
+
+Some existing tests expect `AwaitingChoice` in scenarios where auto-move will now fire instead. These tests will need updating to reflect the new behavior (no `AwaitingChoice`, movement events emitted directly). Affected tests will be identified during implementation and updated to match the new expected event sequence.

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -656,3 +656,42 @@ async def handle_start_game(ctx: HandlerContext) -> HandlerResult:
 # In app/services/websocket/handlers/__init__.py
 from . import authenticate, leave, ping, ready, start_game  # Add new import
 ```
+
+## Reconnection & Game State Sync
+
+### Game State Persistence
+
+Game state is stored in Redis with a 6-hour TTL. Key pattern: `room:{room_id}:game_state`.
+
+### Reconnection Flow
+
+When a player reconnects to a room with an active game:
+
+1. Client connects to `ws://host/api/v1/ws`
+2. Client sends: `{"type": "authenticate", "payload": {"token": "<jwt>", "room_code": "ABC123"}}`
+3. Server responds with `authenticated` message (including room snapshot)
+4. If room status is `in_game`, server auto-pushes `game_state` message with full state
+
+### game_state Request
+
+Clients can also explicitly request the current game state:
+
+```json
+// Client sends:
+{"type": "game_state", "request_id": "..."}
+
+// Server responds:
+{"type": "game_state", "request_id": "...", "payload": {"game_state": {...}}}
+```
+
+Returns `GAME_NOT_FOUND` error if no game is in progress.
+
+### Auto-Move for Disconnected Players
+
+When a game action is processed (or a game starts) and the next player to move is disconnected:
+
+1. Server waits `TURN_SKIP_GRACE_PERIOD` seconds (default: 10s, configurable)
+2. Re-checks if the player reconnected during the grace period
+3. If still disconnected, auto-plays their turn (random roll, first available move)
+4. `TurnStarted` events for auto-played turns include `auto_played: true`
+5. Handles consecutive disconnected players (loops until a connected player's turn)

--- a/scripts/emulate_game.py
+++ b/scripts/emulate_game.py
@@ -212,7 +212,9 @@ def _player_color_code(player_id, state: GameState) -> str:
 def render_board(state: GameState) -> str:
     """Render the compact board table."""
     lines = []
-    lines.append(f"  {DIM}\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510{RESET}")
+    lines.append(
+        f"  {DIM}\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510{RESET}"
+    )
 
     current_pid = state.current_turn.player_id if state.current_turn else None
 
@@ -222,20 +224,26 @@ def render_board(state: GameState) -> str:
         is_current = player.player_id == current_pid
         marker = f"{BOLD}\u25ba" if is_current else " "
 
-        stacks_str = " ".join(format_stack(s) for s in sorted(player.stacks, key=lambda s: s.stack_id))
+        stacks_str = " ".join(
+            format_stack(s) for s in sorted(player.stacks, key=lambda s: s.stack_id)
+        )
 
         # Pad label to 8 chars (accounting for color codes)
         row = f"  {DIM}\u2502{RESET}{marker}{color}{label:<8}{RESET}{DIM}\u2502{RESET} {stacks_str}"
         # Add closing border with padding
         # We need to calculate visible length for padding
-        visible_stacks = " ".join(_visible_stack(s) for s in sorted(player.stacks, key=lambda s: s.stack_id))
+        visible_stacks = " ".join(
+            _visible_stack(s) for s in sorted(player.stacks, key=lambda s: s.stack_id)
+        )
         pad_needed = 39 - len(visible_stacks)
         if pad_needed > 0:
             row += " " * pad_needed
         row += f"{DIM}\u2502{RESET}"
         lines.append(row)
 
-    lines.append(f"  {DIM}\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518{RESET}")
+    lines.append(
+        f"  {DIM}\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518{RESET}"
+    )
     return "\n".join(lines)
 
 
@@ -421,7 +429,9 @@ def run():
         if winner:
             winner_name = _name_by_id(winner, state)
             print()
-            print(f"  {BOLD}{CYAN}\U0001f3c6\U0001f3c6\U0001f3c6 {winner_name} wins the game! \U0001f3c6\U0001f3c6\U0001f3c6{RESET}")
+            print(
+                f"  {BOLD}{CYAN}\U0001f3c6\U0001f3c6\U0001f3c6 {winner_name} wins the game! \U0001f3c6\U0001f3c6\U0001f3c6{RESET}"
+            )
             print()
             print(f"  {DIM}Game finished in {action_num} actions.{RESET}")
             print(f"  {DIM}Press any key to exit.{RESET}")

--- a/tests/test_auto_play.py
+++ b/tests/test_auto_play.py
@@ -1,0 +1,140 @@
+"""Tests for auto-play logic for disconnected players."""
+
+from uuid import UUID
+
+import pytest
+
+from app.schemas.game_engine import (
+    BoardSetup,
+    CurrentEvent,
+    GamePhase,
+    GameState,
+    PendingCapture,
+    Player,
+    Stack,
+    StackState,
+    Turn,
+)
+from app.services.game.auto_play import auto_play_turn, get_next_auto_action
+from app.services.game.engine.actions import CaptureChoiceAction, MoveAction, RollAction
+
+PLAYER_1_ID = UUID("00000000-0000-0000-0000-000000000001")
+PLAYER_2_ID = UUID("00000000-0000-0000-0000-000000000002")
+
+
+def _make_player(pid: UUID, name: str, color: str, turn_order: int, start: int) -> Player:
+    return Player(
+        player_id=pid,
+        name=name,
+        color=color,
+        turn_order=turn_order,
+        abs_starting_index=start,
+        stacks=[Stack(stack_id=f"stack_{i}", state=StackState.HELL, height=1, progress=0) for i in range(1, 5)],
+    )
+
+
+def _make_board_setup() -> BoardSetup:
+    return BoardSetup(
+        grid_length=6,
+        loop_length=52,
+        squares_to_win=55,
+        squares_to_homestretch=49,
+        starting_positions=[0, 13, 26, 39],
+        safe_spaces=[0, 7, 13, 20, 26, 33, 39, 46],
+        get_out_rolls=[6],
+    )
+
+
+def _make_state(
+    current_event: CurrentEvent = CurrentEvent.PLAYER_ROLL,
+    rolls_to_allocate: list[int] | None = None,
+    legal_moves: list[str] | None = None,
+    pending_capture=None,
+) -> GameState:
+    players = [
+        _make_player(PLAYER_1_ID, "P1", "red", 1, 0),
+        _make_player(PLAYER_2_ID, "P2", "blue", 2, 13),
+    ]
+    turn = Turn(
+        player_id=PLAYER_1_ID,
+        initial_roll=True,
+        rolls_to_allocate=rolls_to_allocate or [],
+        legal_moves=legal_moves or [],
+        current_turn_order=1,
+        extra_rolls=0,
+        pending_capture=pending_capture,
+    )
+    return GameState(
+        phase=GamePhase.IN_PROGRESS,
+        players=players,
+        current_event=current_event,
+        board_setup=_make_board_setup(),
+        current_turn=turn,
+        event_seq=10,
+    )
+
+
+class TestGetNextAutoAction:
+    def test_returns_roll_action_for_player_roll(self) -> None:
+        state = _make_state(current_event=CurrentEvent.PLAYER_ROLL)
+        action = get_next_auto_action(state, PLAYER_1_ID)
+
+        assert isinstance(action, RollAction)
+        assert 1 <= action.value <= 6
+
+    def test_returns_move_action_for_player_choice(self) -> None:
+        # Player has a stack on ROAD that can move
+        state = _make_state(
+            current_event=CurrentEvent.PLAYER_CHOICE,
+            rolls_to_allocate=[3],
+            legal_moves=["stack_1"],
+        )
+        # Put stack_1 on ROAD so it has legal moves
+        state.players[0].stacks[0] = Stack(
+            stack_id="stack_1", state=StackState.ROAD, height=1, progress=0
+        )
+        action = get_next_auto_action(state, PLAYER_1_ID)
+
+        assert isinstance(action, MoveAction)
+
+    def test_returns_capture_choice_for_capture_choice(self) -> None:
+        pending = PendingCapture(
+            capturable_targets=[
+                f"{PLAYER_2_ID}:stack_1",
+                f"{PLAYER_2_ID}:stack_2",
+            ],
+            moving_stack_id="stack_1",
+            position=0,
+        )
+        state = _make_state(
+            current_event=CurrentEvent.CAPTURE_CHOICE,
+            pending_capture=pending,
+        )
+        action = get_next_auto_action(state, PLAYER_1_ID)
+
+        assert isinstance(action, CaptureChoiceAction)
+        assert action.choice == f"{PLAYER_2_ID}:stack_1"  # First target
+
+
+class TestAutoPlayTurn:
+    def test_plays_full_turn_and_transitions(self) -> None:
+        # All stacks in HELL, need a 6 to get out
+        state = _make_state(current_event=CurrentEvent.PLAYER_ROLL)
+        new_state, events = auto_play_turn(state, PLAYER_1_ID)
+
+        # Turn should have transitioned to player 2 (or game state updated)
+        # At minimum, events should include DiceRolled
+        assert len(events) > 0
+        dice_events = [e for e in events if e.event_type == "dice_rolled"]
+        assert len(dice_events) >= 1
+
+    def test_turn_ends_eventually(self) -> None:
+        # Ensure auto_play_turn terminates (doesn't infinite loop)
+        state = _make_state(current_event=CurrentEvent.PLAYER_ROLL)
+        new_state, events = auto_play_turn(state, PLAYER_1_ID)
+
+        # Turn must have ended — either next player's turn or game finished
+        assert (
+            new_state.current_turn.player_id != PLAYER_1_ID
+            or new_state.phase == GamePhase.FINISHED
+        )

--- a/tests/test_auto_play.py
+++ b/tests/test_auto_play.py
@@ -2,8 +2,6 @@
 
 from uuid import UUID
 
-import pytest
-
 from app.schemas.game_engine import (
     BoardSetup,
     CurrentEvent,
@@ -29,7 +27,10 @@ def _make_player(pid: UUID, name: str, color: str, turn_order: int, start: int) 
         color=color,
         turn_order=turn_order,
         abs_starting_index=start,
-        stacks=[Stack(stack_id=f"stack_{i}", state=StackState.HELL, height=1, progress=0) for i in range(1, 5)],
+        stacks=[
+            Stack(stack_id=f"stack_{i}", state=StackState.HELL, height=1, progress=0)
+            for i in range(1, 5)
+        ],
     )
 
 
@@ -135,6 +136,5 @@ class TestAutoPlayTurn:
 
         # Turn must have ended — either next player's turn or game finished
         assert (
-            new_state.current_turn.player_id != PLAYER_1_ID
-            or new_state.phase == GamePhase.FINISHED
+            new_state.current_turn.player_id != PLAYER_1_ID or new_state.phase == GamePhase.FINISHED
         )

--- a/tests/test_captures.py
+++ b/tests/test_captures.py
@@ -524,22 +524,16 @@ class TestMultiHeightCaptureDecomposition:
         assert result.success
         state = result.state
 
-        result = process_action(
-            state, MoveAction(stack_id="stack_1_2", roll_value=4), PLAYER_1_ID
-        )
+        result = process_action(state, MoveAction(stack_id="stack_1_2", roll_value=4), PLAYER_1_ID)
         assert result.success
 
         # StackCaptured event should exist
-        capture_event = next(
-            (e for e in result.events if isinstance(e, StackCaptured)), None
-        )
+        capture_event = next((e for e in result.events if isinstance(e, StackCaptured)), None)
         assert capture_event is not None
 
         # StackUpdate should be emitted for the decomposition of the captured stack
         update_events = [e for e in result.events if isinstance(e, StackUpdate)]
-        decomp_event = next(
-            (e for e in update_events if e.player_id == PLAYER_2_ID), None
-        )
+        decomp_event = next((e for e in update_events if e.player_id == PLAYER_2_ID), None)
         assert decomp_event is not None, (
             "StackUpdate should be emitted for captured player's stack decomposition"
         )
@@ -622,9 +616,7 @@ class TestMultiHeightCaptureDecomposition:
         assert result.success
         state = result.state
 
-        result = process_action(
-            state, MoveAction(stack_id="stack_1", roll_value=3), PLAYER_1_ID
-        )
+        result = process_action(state, MoveAction(stack_id="stack_1", roll_value=3), PLAYER_1_ID)
         assert result.success
 
         # StackCaptured should exist
@@ -632,8 +624,7 @@ class TestMultiHeightCaptureDecomposition:
 
         # No StackUpdate for the captured player (height 1 has no decomposition)
         update_events = [
-            e for e in result.events
-            if isinstance(e, StackUpdate) and e.player_id == PLAYER_2_ID
+            e for e in result.events if isinstance(e, StackUpdate) and e.player_id == PLAYER_2_ID
         ]
         assert len(update_events) == 0, (
             "No StackUpdate should be emitted for height-1 capture (no decomposition)"

--- a/tests/test_game_finished.py
+++ b/tests/test_game_finished.py
@@ -328,9 +328,7 @@ class TestGameEndedEvent:
         assert result.success
 
         # GameEnded event should be emitted
-        game_ended = next(
-            (e for e in result.events if isinstance(e, GameEnded)), None
-        )
+        game_ended = next((e for e in result.events if isinstance(e, GameEnded)), None)
         assert game_ended is not None, "GameEnded event should be emitted when player wins"
         assert game_ended.winner_id == PLAYER_1_ID
         assert PLAYER_1_ID in game_ended.final_rankings
@@ -338,9 +336,7 @@ class TestGameEndedEvent:
         # Game phase should be FINISHED
         assert result.state.phase == GamePhase.FINISHED
 
-    def test_game_ended_no_turn_transition_after_win(
-        self, two_player_board_setup: BoardSetup
-    ):
+    def test_game_ended_no_turn_transition_after_win(self, two_player_board_setup: BoardSetup):
         """After a win, no TurnEnded/TurnStarted events should follow GameEnded."""
         player1_stacks = [
             create_stack("stack_1", StackState.HOMESTRETCH, 1, 53),
@@ -392,9 +388,7 @@ class TestGameEndedEvent:
         assert "roll_granted" not in event_types
         assert "turn_ended" not in event_types
 
-    def test_game_ended_with_merged_stack_reaching_heaven(
-        self, two_player_board_setup: BoardSetup
-    ):
+    def test_game_ended_with_merged_stack_reaching_heaven(self, two_player_board_setup: BoardSetup):
         """A merged stack (height 2) reaching heaven with all pieces should end the game."""
         # Player 1 has stack_1_2 (contains 2 pieces) in homestretch + stack_3, stack_4 in heaven
         # When stack_1_2 reaches heaven, all 4 original pieces are in heaven -> game ends
@@ -439,22 +433,16 @@ class TestGameEndedEvent:
         result = process_action(state, RollAction(value=4), PLAYER_1_ID)
         state = result.state
 
-        result = process_action(
-            state, MoveAction(stack_id="stack_1_2", roll_value=4), PLAYER_1_ID
-        )
+        result = process_action(state, MoveAction(stack_id="stack_1_2", roll_value=4), PLAYER_1_ID)
         assert result.success
 
         # GameEnded should be emitted
-        game_ended = next(
-            (e for e in result.events if isinstance(e, GameEnded)), None
-        )
+        game_ended = next((e for e in result.events if isinstance(e, GameEnded)), None)
         assert game_ended is not None, "GameEnded event should be emitted"
         assert game_ended.winner_id == PLAYER_1_ID
         assert result.state.phase == GamePhase.FINISHED
 
-    def test_no_game_ended_when_stacks_still_on_board(
-        self, two_player_board_setup: BoardSetup
-    ):
+    def test_no_game_ended_when_stacks_still_on_board(self, two_player_board_setup: BoardSetup):
         """GameEnded should NOT be emitted when some stacks are still playing."""
         player1_stacks = [
             create_stack("stack_1", StackState.HOMESTRETCH, 1, 53),
@@ -502,8 +490,6 @@ class TestGameEndedEvent:
         assert result.success
 
         # GameEnded should NOT be emitted
-        game_ended = next(
-            (e for e in result.events if isinstance(e, GameEnded)), None
-        )
+        game_ended = next((e for e in result.events if isinstance(e, GameEnded)), None)
         assert game_ended is None, "GameEnded should not be emitted with stacks still playing"
         assert result.state.phase == GamePhase.IN_PROGRESS

--- a/tests/test_game_state_redis.py
+++ b/tests/test_game_state_redis.py
@@ -2,9 +2,20 @@
 
 import json
 from unittest.mock import AsyncMock, patch
+from uuid import UUID
 
 import pytest
 
+from app.schemas.game_engine import (
+    BoardSetup,
+    CurrentEvent,
+    GamePhase,
+    GameState,
+    Player,
+    Stack,
+    StackState,
+    Turn,
+)
 from app.services.game.state import (
     GAME_STATE_TTL,
     delete_game_state,
@@ -86,3 +97,51 @@ async def test_delete_game_state(mock_get_redis: AsyncMock) -> None:
     await delete_game_state(ROOM_ID)
 
     mock_redis.delete.assert_called_once_with(f"room:{ROOM_ID}:game_state")
+
+
+@pytest.mark.asyncio
+@patch("app.services.game.state.get_redis_client")
+async def test_save_game_state_with_real_game_state(mock_get_redis: AsyncMock) -> None:
+    """Verify that a real GameState serializes correctly for Redis storage.
+
+    model_dump(mode='json') must be used to convert UUIDs/enums to JSON-safe types.
+    """
+    mock_redis = AsyncMock()
+    mock_get_redis.return_value = mock_redis
+
+    player = Player(
+        player_id=UUID("00000000-0000-0000-0000-000000000001"),
+        name="P1",
+        color="red",
+        turn_order=1,
+        abs_starting_index=0,
+        stacks=[Stack(stack_id="stack_1", state=StackState.HELL, height=1, progress=0)],
+    )
+    board = BoardSetup(
+        grid_length=6,
+        loop_length=52,
+        squares_to_win=55,
+        squares_to_homestretch=49,
+        starting_positions=[0, 13],
+        safe_spaces=[0, 7],
+        get_out_rolls=[6],
+    )
+    turn = Turn(player_id=player.player_id, current_turn_order=1)
+    state = GameState(
+        phase=GamePhase.IN_PROGRESS,
+        players=[player],
+        current_event=CurrentEvent.PLAYER_ROLL,
+        board_setup=board,
+        current_turn=turn,
+    )
+
+    # This is how handlers should call save_game_state
+    state_dict = state.model_dump(mode="json")
+    await save_game_state(ROOM_ID, state_dict)
+
+    # Verify json.dumps was called successfully (no TypeError on UUIDs)
+    call_args = mock_redis.set.call_args
+    stored_json = call_args[0][1]
+    parsed = json.loads(stored_json)
+    assert parsed["players"][0]["player_id"] == "00000000-0000-0000-0000-000000000001"
+    assert parsed["phase"] == "in_progress"

--- a/tests/test_game_state_redis.py
+++ b/tests/test_game_state_redis.py
@@ -1,0 +1,88 @@
+"""Tests for Redis-backed game state storage."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.game.state import (
+    GAME_STATE_TTL,
+    delete_game_state,
+    get_game_state,
+    save_game_state,
+)
+
+ROOM_ID = "room-test-123"
+SAMPLE_STATE = {"phase": "in_progress", "players": [], "board_setup": {}}
+
+
+@pytest.mark.asyncio
+@patch("app.services.game.state.get_redis_client")
+async def test_save_game_state_writes_json_with_ttl(mock_get_redis: AsyncMock) -> None:
+    mock_redis = AsyncMock()
+    mock_get_redis.return_value = mock_redis
+
+    await save_game_state(ROOM_ID, SAMPLE_STATE)
+
+    mock_redis.set.assert_called_once_with(
+        f"room:{ROOM_ID}:game_state",
+        json.dumps(SAMPLE_STATE),
+        ex=GAME_STATE_TTL,
+    )
+
+
+@pytest.mark.asyncio
+@patch("app.services.game.state.get_redis_client")
+async def test_get_game_state_returns_parsed_json(mock_get_redis: AsyncMock) -> None:
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = json.dumps(SAMPLE_STATE)
+    mock_get_redis.return_value = mock_redis
+
+    result = await get_game_state(ROOM_ID)
+
+    assert result == SAMPLE_STATE
+    mock_redis.get.assert_called_once_with(f"room:{ROOM_ID}:game_state")
+
+
+@pytest.mark.asyncio
+@patch("app.services.game.state.get_redis_client")
+async def test_get_game_state_returns_none_when_not_found(mock_get_redis: AsyncMock) -> None:
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = None
+    mock_get_redis.return_value = mock_redis
+
+    result = await get_game_state(ROOM_ID)
+    assert result is None
+
+
+@pytest.mark.asyncio
+@patch("app.services.game.state.get_redis_client")
+async def test_get_game_state_returns_none_on_redis_error(mock_get_redis: AsyncMock) -> None:
+    mock_redis = AsyncMock()
+    mock_redis.get.side_effect = Exception("Redis connection failed")
+    mock_get_redis.return_value = mock_redis
+
+    result = await get_game_state(ROOM_ID)
+    assert result is None
+
+
+@pytest.mark.asyncio
+@patch("app.services.game.state.get_redis_client")
+async def test_save_game_state_raises_on_redis_error(mock_get_redis: AsyncMock) -> None:
+    mock_redis = AsyncMock()
+    mock_redis.set.side_effect = Exception("Redis connection failed")
+    mock_get_redis.return_value = mock_redis
+
+    with pytest.raises(Exception, match="Redis connection failed"):
+        await save_game_state(ROOM_ID, SAMPLE_STATE)
+
+
+@pytest.mark.asyncio
+@patch("app.services.game.state.get_redis_client")
+async def test_delete_game_state(mock_get_redis: AsyncMock) -> None:
+    mock_redis = AsyncMock()
+    mock_get_redis.return_value = mock_redis
+
+    await delete_game_state(ROOM_ID)
+
+    mock_redis.delete.assert_called_once_with(f"room:{ROOM_ID}:game_state")

--- a/tests/test_heaven_extra_rolls.py
+++ b/tests/test_heaven_extra_rolls.py
@@ -204,9 +204,7 @@ class TestHeavenExtraRollFullFlow:
         heaven_grants = [e for e in roll_granted if e.reason == "reached_heaven"]
         assert len(heaven_grants) == 1
 
-    def test_game_ending_heaven_does_not_grant_usable_roll(
-        self, standard_board_setup: BoardSetup
-    ):
+    def test_game_ending_heaven_does_not_grant_usable_roll(self, standard_board_setup: BoardSetup):
         """When the last stack reaches heaven (game over), no extra roll is used."""
         player1_stacks = [
             create_stack("stack_1", StackState.HOMESTRETCH, 1, 52),

--- a/tests/test_ws_authenticate_reconnect.py
+++ b/tests/test_ws_authenticate_reconnect.py
@@ -1,0 +1,161 @@
+"""Tests for authenticate handler's mid-game reconnection auto-push."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.ws import MessageType, WSClientMessage
+from app.services.websocket.handlers.authenticate import handle_authenticate
+from app.services.websocket.handlers.base import HandlerContext
+
+
+USER_ID = "00000000-0000-0000-0000-000000000001"
+CONN_ID = "conn-test-456"
+ROOM_ID = "room-test-123"
+ROOM_CODE = "ABC123"
+REQUEST_ID = "00000000-0000-0000-0000-aaaaaaaaaaaa"
+FAKE_TOKEN = "valid.jwt.token"
+
+
+def _make_unauthenticated_context() -> HandlerContext:
+    """Build a HandlerContext with an unauthenticated connection."""
+    manager = MagicMock()
+    connection = MagicMock()
+    connection.authenticated = False
+    connection.user_id = None
+    connection.room_id = None
+    manager.get_connection.return_value = connection
+    manager.authenticate_connection = AsyncMock(return_value=True)
+    manager.send_to_connection = AsyncMock(return_value=True)
+
+    message = WSClientMessage(
+        type=MessageType.AUTHENTICATE,
+        request_id=REQUEST_ID,
+        payload={"token": FAKE_TOKEN, "room_code": ROOM_CODE},
+    )
+    return HandlerContext(
+        connection_id=CONN_ID,
+        user_id="",
+        message=message,
+        manager=manager,
+    )
+
+
+def _make_room_snapshot(status: str = "open"):
+    """Create a mock room snapshot with given status."""
+    snapshot = MagicMock()
+    snapshot.room_id = ROOM_ID
+    snapshot.code = ROOM_CODE
+    snapshot.status = status
+    snapshot.visibility = "public"
+    snapshot.ruleset_id = "standard"
+    snapshot.max_players = 4
+    snapshot.version = 1
+    seat = MagicMock()
+    seat.user_id = USER_ID
+    seat.display_name = "Player 1"
+    seat.ready = "ready"
+    seat.connected = True
+    seat.is_host = True
+    seat.seat_index = 0
+    snapshot.seats = [seat]
+    return snapshot
+
+
+class TestAuthenticateAutoGameState:
+    """Test that authenticate handler auto-pushes game state for in_game rooms."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.websocket.handlers.authenticate.get_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.authenticate.get_room_service")
+    @patch("app.services.websocket.handlers.authenticate.get_ws_authenticator")
+    async def test_sends_game_state_when_in_game(
+        self,
+        mock_get_auth: MagicMock,
+        mock_get_room: MagicMock,
+        mock_get_game_state: AsyncMock,
+    ) -> None:
+        # Setup auth
+        auth_result = MagicMock()
+        auth_result.success = True
+        auth_result.payload = {"sub": USER_ID}
+        mock_get_auth.return_value.validate_token = AsyncMock(return_value=auth_result)
+
+        # Setup room service
+        room_service = AsyncMock()
+        room_service.validate_room_access.return_value = (ROOM_ID, None)
+        room_service.get_room_snapshot.return_value = _make_room_snapshot(status="in_game")
+        mock_get_room.return_value = room_service
+
+        # Setup game state
+        game_state_dict = {"phase": "in_progress", "players": []}
+        mock_get_game_state.return_value = game_state_dict
+
+        ctx = _make_unauthenticated_context()
+        result = await handle_authenticate(ctx)
+
+        assert result.success
+
+        # Verify game state was sent to connection
+        ctx.manager.send_to_connection.assert_called_once()
+        call_args = ctx.manager.send_to_connection.call_args
+        assert call_args[0][0] == CONN_ID
+        sent_message = call_args[0][1]
+        assert sent_message.type == MessageType.GAME_STATE
+        assert sent_message.payload["game_state"] == game_state_dict
+
+    @pytest.mark.asyncio
+    @patch("app.services.websocket.handlers.authenticate.get_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.authenticate.get_room_service")
+    @patch("app.services.websocket.handlers.authenticate.get_ws_authenticator")
+    async def test_no_game_state_sent_when_lobby(
+        self,
+        mock_get_auth: MagicMock,
+        mock_get_room: MagicMock,
+        mock_get_game_state: AsyncMock,
+    ) -> None:
+        auth_result = MagicMock()
+        auth_result.success = True
+        auth_result.payload = {"sub": USER_ID}
+        mock_get_auth.return_value.validate_token = AsyncMock(return_value=auth_result)
+
+        room_service = AsyncMock()
+        room_service.validate_room_access.return_value = (ROOM_ID, None)
+        room_service.get_room_snapshot.return_value = _make_room_snapshot(status="open")
+        mock_get_room.return_value = room_service
+
+        ctx = _make_unauthenticated_context()
+        result = await handle_authenticate(ctx)
+
+        assert result.success
+        mock_get_game_state.assert_not_called()
+        ctx.manager.send_to_connection.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("app.services.websocket.handlers.authenticate.get_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.authenticate.get_room_service")
+    @patch("app.services.websocket.handlers.authenticate.get_ws_authenticator")
+    async def test_auth_succeeds_even_if_game_state_missing(
+        self,
+        mock_get_auth: MagicMock,
+        mock_get_room: MagicMock,
+        mock_get_game_state: AsyncMock,
+    ) -> None:
+        auth_result = MagicMock()
+        auth_result.success = True
+        auth_result.payload = {"sub": USER_ID}
+        mock_get_auth.return_value.validate_token = AsyncMock(return_value=auth_result)
+
+        room_service = AsyncMock()
+        room_service.validate_room_access.return_value = (ROOM_ID, None)
+        room_service.get_room_snapshot.return_value = _make_room_snapshot(status="in_game")
+        mock_get_room.return_value = room_service
+
+        mock_get_game_state.return_value = None  # Game state missing
+
+        ctx = _make_unauthenticated_context()
+        result = await handle_authenticate(ctx)
+
+        # Auth still succeeds — game state push is best-effort
+        assert result.success
+        ctx.manager.send_to_connection.assert_not_called()

--- a/tests/test_ws_authenticate_reconnect.py
+++ b/tests/test_ws_authenticate_reconnect.py
@@ -8,7 +8,6 @@ from app.schemas.ws import MessageType, WSClientMessage
 from app.services.websocket.handlers.authenticate import handle_authenticate
 from app.services.websocket.handlers.base import HandlerContext
 
-
 USER_ID = "00000000-0000-0000-0000-000000000001"
 CONN_ID = "conn-test-456"
 ROOM_ID = "room-test-123"

--- a/tests/test_ws_game_action_handler.py
+++ b/tests/test_ws_game_action_handler.py
@@ -6,7 +6,7 @@ import pytest
 
 from app.schemas.ws import MessageType, WSClientMessage
 from app.services.websocket.handlers.base import HandlerContext
-from app.services.websocket.handlers.game import handle_game_action
+from app.services.websocket.handlers.game import handle_game_action, _auto_play_disconnected_turns
 
 USER_ID = "00000000-0000-0000-0000-000000000001"
 ROOM_ID = "room-test-123"
@@ -238,3 +238,87 @@ class TestHandleGameActionSuccess:
         assert call_args["action_type"] == "move"
         assert call_args["stack_id"] == "stack_1"
         assert call_args["roll_value"] == 5
+
+
+class TestHandleGameActionAutoMove:
+    """Test auto-move for disconnected players after action processing."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.websocket.handlers.game.get_settings")
+    @patch("app.services.websocket.handlers.game.get_room_service")
+    @patch("app.services.websocket.handlers.game.auto_play_turn")
+    @patch("app.services.websocket.handlers.game.save_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.game.process_action")
+    @patch("app.services.websocket.handlers.game.build_action_from_payload")
+    @patch("app.schemas.game_engine.GameState.model_validate")
+    @patch("app.services.websocket.handlers.game.get_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.game.asyncio")
+    async def test_auto_plays_disconnected_player_after_grace(
+        self,
+        mock_asyncio: MagicMock,
+        mock_get_state: AsyncMock,
+        mock_validate: MagicMock,
+        mock_build: MagicMock,
+        mock_process: MagicMock,
+        mock_save: AsyncMock,
+        mock_auto_play: MagicMock,
+        mock_get_room: MagicMock,
+        mock_get_settings: MagicMock,
+    ) -> None:
+        # Setup: action processes successfully, next player is disconnected
+        mock_get_state.return_value = _make_mock_game_state_dict()
+        mock_validate.return_value = MagicMock()
+        mock_build.return_value = MagicMock()
+
+        # The process result - next player has turn_order=2
+        process_result = _make_mock_process_result(success=True)
+        current_turn = MagicMock()
+        current_turn.player_id = "00000000-0000-0000-0000-000000000002"
+        process_result.state.current_turn = current_turn
+        process_result.state.phase.value = "in_progress"
+        process_result.state.players = [MagicMock(), MagicMock()]  # 2 players
+        mock_process.return_value = process_result
+
+        # Room service returns snapshot showing player 2 disconnected
+        room_service = AsyncMock()
+        seat1 = MagicMock()
+        seat1.user_id = USER_ID
+        seat1.connected = True
+        seat2 = MagicMock()
+        seat2.user_id = "00000000-0000-0000-0000-000000000002"
+        seat2.connected = False
+        snapshot = MagicMock()
+        snapshot.seats = [seat1, seat2]
+        room_service.get_room_snapshot.return_value = snapshot
+        mock_get_room.return_value = room_service
+
+        # Settings
+        settings = MagicMock()
+        settings.TURN_SKIP_GRACE_PERIOD = 0  # No delay in tests
+        mock_get_settings.return_value = settings
+
+        # auto_play_turn returns new state where next player (P1) is connected
+        auto_state = MagicMock()
+        auto_turn_mock = MagicMock()
+        auto_turn_mock.player_id = USER_ID  # Back to P1 who is connected
+        auto_state.current_turn = auto_turn_mock
+        auto_state.phase.value = "in_progress"
+        auto_state.model_dump.return_value = {"phase": "in_progress", "auto_played": True}
+        auto_event = MagicMock()
+        auto_event.model_dump.return_value = {"event_type": "dice_rolled"}
+        auto_event.event_type = "dice_rolled"
+        turn_started_event = MagicMock()
+        turn_started_event.event_type = "turn_started"
+        turn_started_event.model_dump.return_value = {"event_type": "turn_started", "auto_played": False}
+        mock_auto_play.return_value = (auto_state, [turn_started_event, auto_event])
+
+        # asyncio.sleep should be awaitable
+        mock_asyncio.sleep = AsyncMock()
+
+        ctx = _make_context()
+        result = await handle_game_action(ctx)
+
+        assert result.success
+        mock_auto_play.assert_called_once()
+        # save_game_state called twice: once for original action, once for auto-play
+        assert mock_save.call_count == 2

--- a/tests/test_ws_game_action_handler.py
+++ b/tests/test_ws_game_action_handler.py
@@ -6,7 +6,7 @@ import pytest
 
 from app.schemas.ws import MessageType, WSClientMessage
 from app.services.websocket.handlers.base import HandlerContext
-from app.services.websocket.handlers.game import handle_game_action, _auto_play_disconnected_turns
+from app.services.websocket.handlers.game import handle_game_action
 
 USER_ID = "00000000-0000-0000-0000-000000000001"
 ROOM_ID = "room-test-123"
@@ -226,9 +226,7 @@ class TestHandleGameActionSuccess:
         mock_build.return_value = MagicMock()
         mock_process.return_value = _make_mock_process_result(success=True)
 
-        ctx = _make_context(
-            payload={"action_type": "move", "stack_id": "stack_1", "roll_value": 5}
-        )
+        ctx = _make_context(payload={"action_type": "move", "stack_id": "stack_1", "roll_value": 5})
         result = await handle_game_action(ctx)
 
         assert result.success
@@ -309,7 +307,10 @@ class TestHandleGameActionAutoMove:
         auto_event.event_type = "dice_rolled"
         turn_started_event = MagicMock()
         turn_started_event.event_type = "turn_started"
-        turn_started_event.model_dump.return_value = {"event_type": "turn_started", "auto_played": False}
+        turn_started_event.model_dump.return_value = {
+            "event_type": "turn_started",
+            "auto_played": False,
+        }
         mock_auto_play.return_value = (auto_state, [turn_started_event, auto_event])
 
         # asyncio.sleep should be awaitable

--- a/tests/test_ws_game_action_handler.py
+++ b/tests/test_ws_game_action_handler.py
@@ -1,12 +1,26 @@
 """Tests for handle_game_action WebSocket handler."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
 
 import pytest
 
+from app.schemas.game_engine import (
+    BoardSetup,
+    CurrentEvent,
+    GamePhase,
+    GameState,
+    Player,
+    Stack,
+    StackState,
+    Turn,
+)
 from app.schemas.ws import MessageType, WSClientMessage
 from app.services.websocket.handlers.base import HandlerContext
-from app.services.websocket.handlers.game import handle_game_action
+from app.services.websocket.handlers.game import (
+    _auto_play_disconnected_turns,
+    handle_game_action,
+)
 
 USER_ID = "00000000-0000-0000-0000-000000000001"
 ROOM_ID = "room-test-123"
@@ -323,3 +337,181 @@ class TestHandleGameActionAutoMove:
         mock_auto_play.assert_called_once()
         # save_game_state called twice: once for original action, once for auto-play
         assert mock_save.call_count == 2
+
+
+# --- Helpers for integration tests (real engine, no auto_play_turn mock) ---
+
+P1_UUID = UUID("00000000-0000-0000-0000-000000000001")
+P2_UUID = UUID("00000000-0000-0000-0000-000000000002")
+P3_UUID = UUID("00000000-0000-0000-0000-000000000003")
+
+
+def _make_hell_stacks() -> list[Stack]:
+    return [
+        Stack(stack_id=f"stack_{i}", state=StackState.HELL, height=1, progress=0)
+        for i in range(1, 5)
+    ]
+
+
+def _make_two_player_board() -> BoardSetup:
+    return BoardSetup(
+        grid_length=6,
+        loop_length=52,
+        squares_to_win=55,
+        squares_to_homestretch=49,
+        starting_positions=[0, 26],
+        safe_spaces=[0, 7, 13, 20, 26, 33, 39, 46],
+        get_out_rolls=[6],
+    )
+
+
+class TestAutoPlayIntegration:
+    """Integration tests: real engine verifies UUID handling and auto_played marking."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.game.auto_play.random.randint", return_value=1)
+    @patch("app.services.websocket.handlers.game.get_settings")
+    @patch("app.services.websocket.handlers.game.get_room_service")
+    @patch("app.services.websocket.handlers.game.save_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.game.asyncio")
+    async def test_auto_played_only_on_disconnected_players_turn_started(
+        self,
+        mock_asyncio: MagicMock,
+        mock_save: AsyncMock,
+        mock_get_room: MagicMock,
+        mock_get_settings: MagicMock,
+        mock_randint: MagicMock,
+    ) -> None:
+        """P2 disconnected: TurnStarted(P1) after auto-play should NOT be auto_played."""
+        state = GameState(
+            phase=GamePhase.IN_PROGRESS,
+            players=[
+                Player(
+                    player_id=P1_UUID, name="P1", color="red", turn_order=1,
+                    abs_starting_index=0, stacks=_make_hell_stacks(),
+                ),
+                Player(
+                    player_id=P2_UUID, name="P2", color="blue", turn_order=2,
+                    abs_starting_index=26, stacks=_make_hell_stacks(),
+                ),
+            ],
+            current_event=CurrentEvent.PLAYER_ROLL,
+            board_setup=_make_two_player_board(),
+            current_turn=Turn(
+                player_id=P2_UUID, initial_roll=True, rolls_to_allocate=[],
+                legal_moves=[], current_turn_order=2, extra_rolls=0,
+            ),
+            event_seq=10,
+        )
+
+        # P2 disconnected, P1 connected
+        seat1 = MagicMock(user_id=str(P1_UUID), connected=True)
+        seat2 = MagicMock(user_id=str(P2_UUID), connected=False)
+        room_service = AsyncMock()
+        room_service.get_room_snapshot.return_value = MagicMock(seats=[seat1, seat2])
+        mock_get_room.return_value = room_service
+
+        settings = MagicMock()
+        settings.TURN_SKIP_GRACE_PERIOD = 0
+        mock_get_settings.return_value = settings
+        mock_asyncio.sleep = AsyncMock()
+
+        auto_events, auto_played_ids = await _auto_play_disconnected_turns(
+            "room-123", state, MagicMock()
+        )
+
+        # P2 was auto-played, P1 was not
+        assert str(P2_UUID) in auto_played_ids
+        assert str(P1_UUID) not in auto_played_ids
+
+        # Real engine produced events (proves UUID was passed correctly, not str)
+        assert len(auto_events) > 0
+
+        # TurnStarted(P1) should NOT be auto_played (P1 is connected)
+        turn_started = [e for e in auto_events if e.get("event_type") == "turn_started"]
+        assert len(turn_started) >= 1
+        for ts in turn_started:
+            assert ts["auto_played"] is not True, (
+                f"TurnStarted for connected player {ts['player_id']} should not be auto_played"
+            )
+
+    @pytest.mark.asyncio
+    @patch("app.services.game.auto_play.random.randint", return_value=1)
+    @patch("app.services.websocket.handlers.game.get_settings")
+    @patch("app.services.websocket.handlers.game.get_room_service")
+    @patch("app.services.websocket.handlers.game.save_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.game.asyncio")
+    async def test_consecutive_disconnected_marks_intermediate_not_final(
+        self,
+        mock_asyncio: MagicMock,
+        mock_save: AsyncMock,
+        mock_get_room: MagicMock,
+        mock_get_settings: MagicMock,
+        mock_randint: MagicMock,
+    ) -> None:
+        """P2+P3 disconnected: TurnStarted(P3) marked auto_played, TurnStarted(P1) not."""
+        board = BoardSetup(
+            grid_length=6, loop_length=52, squares_to_win=55,
+            squares_to_homestretch=49, starting_positions=[0, 13, 26],
+            safe_spaces=[0, 7, 13, 20, 26, 33, 39, 46],
+            get_out_rolls=[6],
+        )
+        state = GameState(
+            phase=GamePhase.IN_PROGRESS,
+            players=[
+                Player(
+                    player_id=P1_UUID, name="P1", color="red", turn_order=1,
+                    abs_starting_index=0, stacks=_make_hell_stacks(),
+                ),
+                Player(
+                    player_id=P2_UUID, name="P2", color="blue", turn_order=2,
+                    abs_starting_index=13, stacks=_make_hell_stacks(),
+                ),
+                Player(
+                    player_id=P3_UUID, name="P3", color="green", turn_order=3,
+                    abs_starting_index=26, stacks=_make_hell_stacks(),
+                ),
+            ],
+            current_event=CurrentEvent.PLAYER_ROLL,
+            board_setup=board,
+            current_turn=Turn(
+                player_id=P2_UUID, initial_roll=True, rolls_to_allocate=[],
+                legal_moves=[], current_turn_order=2, extra_rolls=0,
+            ),
+            event_seq=10,
+        )
+
+        seat1 = MagicMock(user_id=str(P1_UUID), connected=True)
+        seat2 = MagicMock(user_id=str(P2_UUID), connected=False)
+        seat3 = MagicMock(user_id=str(P3_UUID), connected=False)
+        room_service = AsyncMock()
+        room_service.get_room_snapshot.return_value = MagicMock(seats=[seat1, seat2, seat3])
+        mock_get_room.return_value = room_service
+
+        settings = MagicMock()
+        settings.TURN_SKIP_GRACE_PERIOD = 0
+        mock_get_settings.return_value = settings
+        mock_asyncio.sleep = AsyncMock()
+
+        auto_events, auto_played_ids = await _auto_play_disconnected_turns(
+            "room-123", state, MagicMock()
+        )
+
+        # Both P2 and P3 were auto-played
+        assert str(P2_UUID) in auto_played_ids
+        assert str(P3_UUID) in auto_played_ids
+        assert str(P1_UUID) not in auto_played_ids
+
+        turn_started = [e for e in auto_events if e.get("event_type") == "turn_started"]
+        assert len(turn_started) >= 2  # TurnStarted(P3) and TurnStarted(P1)
+
+        for ts in turn_started:
+            pid = ts["player_id"]
+            if pid == str(P3_UUID):
+                assert ts["auto_played"] is True, (
+                    "TurnStarted for disconnected P3 should be auto_played"
+                )
+            elif pid == str(P1_UUID):
+                assert ts["auto_played"] is not True, (
+                    "TurnStarted for connected P1 should not be auto_played"
+                )

--- a/tests/test_ws_game_state_handler.py
+++ b/tests/test_ws_game_state_handler.py
@@ -1,0 +1,86 @@
+"""Tests for handle_game_state WebSocket handler."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.ws import MessageType, WSClientMessage
+from app.services.websocket.handlers.base import HandlerContext
+from app.services.websocket.handlers.game_state import handle_game_state
+
+USER_ID = "00000000-0000-0000-0000-000000000001"
+ROOM_ID = "room-test-123"
+CONN_ID = "conn-test-456"
+REQUEST_ID = "00000000-0000-0000-0000-aaaaaaaaaaaa"
+
+
+def _make_context(
+    user_id: str = USER_ID,
+    authenticated: bool = True,
+    room_id: str | None = ROOM_ID,
+    connection_exists: bool = True,
+) -> HandlerContext:
+    """Build a HandlerContext with a mocked manager."""
+    manager = MagicMock()
+
+    if connection_exists:
+        connection = MagicMock()
+        connection.authenticated = authenticated
+        connection.room_id = room_id
+        connection.user_id = user_id
+        manager.get_connection.return_value = connection
+    else:
+        manager.get_connection.return_value = None
+
+    message = WSClientMessage(
+        type=MessageType.GAME_STATE,
+        request_id=REQUEST_ID,
+    )
+    return HandlerContext(
+        connection_id=CONN_ID,
+        user_id=user_id,
+        message=message,
+        manager=manager,
+    )
+
+
+class TestHandleGameStateErrors:
+    @pytest.mark.asyncio
+    async def test_not_authenticated(self) -> None:
+        ctx = _make_context(authenticated=False)
+        result = await handle_game_state(ctx)
+        assert not result.success
+        assert result.response.payload["error_code"] == "NOT_AUTHENTICATED"
+
+    @pytest.mark.asyncio
+    async def test_not_in_room(self) -> None:
+        ctx = _make_context(room_id=None)
+        result = await handle_game_state(ctx)
+        assert not result.success
+        assert result.response.payload["error_code"] == "NOT_IN_ROOM"
+
+    @pytest.mark.asyncio
+    @patch("app.services.websocket.handlers.game_state.get_game_state", new_callable=AsyncMock)
+    async def test_no_game_in_progress(self, mock_get_state: AsyncMock) -> None:
+        mock_get_state.return_value = None
+        ctx = _make_context()
+        result = await handle_game_state(ctx)
+        assert not result.success
+        assert result.response.payload["error_code"] == "GAME_NOT_FOUND"
+
+
+class TestHandleGameStateSuccess:
+    @pytest.mark.asyncio
+    @patch("app.services.websocket.handlers.game_state.get_game_state", new_callable=AsyncMock)
+    async def test_returns_full_game_state(self, mock_get_state: AsyncMock) -> None:
+        game_state_dict = {"phase": "in_progress", "players": [{"id": "p1"}]}
+        mock_get_state.return_value = game_state_dict
+
+        ctx = _make_context()
+        result = await handle_game_state(ctx)
+
+        assert result.success
+        assert result.response.type == MessageType.GAME_STATE
+        assert result.response.request_id == REQUEST_ID
+        assert result.response.payload["game_state"] == game_state_dict
+        assert result.broadcast is None  # Not broadcast to room

--- a/tests/test_ws_start_game_handler_flow.py
+++ b/tests/test_ws_start_game_handler_flow.py
@@ -481,3 +481,75 @@ class TestStartGameFirstPlayerAutoMove:
         mock_auto_play.assert_called_once()
         # save_game_state called twice: once for initial state, once for auto-play
         assert mock_save_game_state.call_count == 2
+
+
+class TestStartGameAutoPlayIntegration:
+    """Integration tests: real engine verifies auto_played on correct TurnStarted."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.game.auto_play.random.randint", return_value=1)
+    @patch("app.services.websocket.handlers.start_game.get_settings")
+    @patch("app.services.websocket.handlers.start_game.save_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.start_game.get_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.start_game.get_room_service")
+    @patch("app.services.websocket.handlers.start_game.asyncio")
+    async def test_first_player_disconnected_marks_correct_turn_started(
+        self,
+        mock_asyncio: MagicMock,
+        mock_get_room_service: MagicMock,
+        mock_get_game_state: AsyncMock,
+        mock_save_game_state: AsyncMock,
+        mock_get_settings: MagicMock,
+        mock_randint: MagicMock,
+    ) -> None:
+        """First player disconnected: their TurnStarted auto_played, next player's not."""
+        snapshot = RoomSnapshotData(
+            room_id=ROOM_ID,
+            code="ABC123",
+            status="ready_to_start",
+            visibility="private",
+            ruleset_id="classic",
+            max_players=4,
+            seats=[
+                SeatData(
+                    seat_index=0, user_id=HOST_ID, display_name="Host",
+                    ready="ready", connected=False, is_host=True,
+                ),
+                SeatData(
+                    seat_index=1, user_id=PLAYER_2_ID, display_name="Player 2",
+                    ready="ready", connected=True, is_host=False,
+                ),
+                SeatData(seat_index=2),
+                SeatData(seat_index=3),
+            ],
+            version=1,
+        )
+
+        mock_service = AsyncMock()
+        mock_service.get_room_snapshot.return_value = snapshot
+        mock_service.update_room_status_to_in_game = AsyncMock()
+        mock_get_room_service.return_value = mock_service
+        mock_get_game_state.return_value = None
+
+        settings = MagicMock()
+        settings.TURN_SKIP_GRACE_PERIOD = 0
+        mock_get_settings.return_value = settings
+        mock_asyncio.sleep = AsyncMock()
+
+        ctx = _make_context()
+        result = await handle_start_game(ctx)
+
+        assert result.success
+
+        all_events = result.broadcast.payload["events"]
+        turn_started = [e for e in all_events if e.get("event_type") == "turn_started"]
+
+        # Host (first player) was auto-played → their TurnStarted marked
+        host_ts = [ts for ts in turn_started if ts["player_id"] == HOST_ID]
+        assert len(host_ts) == 1
+        assert host_ts[0]["auto_played"] is True
+
+        # Player 2 is connected → their TurnStarted NOT marked
+        p2_ts = [ts for ts in turn_started if ts["player_id"] == PLAYER_2_ID]
+        assert len(p2_ts) == 1
+        assert p2_ts[0]["auto_played"] is not True

--- a/tests/test_ws_start_game_handler_flow.py
+++ b/tests/test_ws_start_game_handler_flow.py
@@ -1,8 +1,8 @@
 """Tests for handle_start_game WebSocket handler."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID
+
+import pytest
 
 from app.schemas.ws import MessageType, WSClientMessage
 from app.services.room.service import RoomSnapshotData, SeatData

--- a/tests/test_ws_start_game_handler_flow.py
+++ b/tests/test_ws_start_game_handler_flow.py
@@ -9,6 +9,8 @@ from app.services.room.service import RoomSnapshotData, SeatData
 from app.services.websocket.handlers.base import HandlerContext
 from app.services.websocket.handlers.start_game import handle_start_game
 
+PLAYER_3_ID = "00000000-0000-0000-0000-000000000003"
+
 # Fixed UUIDs
 HOST_ID = "00000000-0000-0000-0000-000000000001"
 PLAYER_2_ID = "00000000-0000-0000-0000-000000000002"
@@ -390,3 +392,92 @@ class TestHandleStartGameSettings:
         game_state = result.response.payload["game_state"]
         assert game_state["board_setup"]["squares_to_win"] == 55
         assert game_state["board_setup"]["get_out_rolls"] == [6]
+
+
+class TestStartGameFirstPlayerAutoMove:
+    """Test that start_game auto-plays the first player if disconnected."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.websocket.handlers.start_game.get_settings")
+    @patch("app.services.websocket.handlers.start_game.auto_play_turn")
+    @patch("app.services.websocket.handlers.start_game.save_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.start_game.get_game_state", new_callable=AsyncMock)
+    @patch("app.services.websocket.handlers.start_game.get_room_service")
+    @patch("app.services.websocket.handlers.start_game.asyncio")
+    async def test_auto_plays_first_player_if_disconnected(
+        self,
+        mock_asyncio: MagicMock,
+        mock_get_room_service: MagicMock,
+        mock_get_game_state: AsyncMock,
+        mock_save_game_state: AsyncMock,
+        mock_auto_play: MagicMock,
+        mock_get_settings: MagicMock,
+    ) -> None:
+        # Host is connected but first player (host) is disconnected in seat data
+        snapshot = RoomSnapshotData(
+            room_id=ROOM_ID,
+            code="ABC123",
+            status="ready_to_start",
+            visibility="private",
+            ruleset_id="classic",
+            max_players=4,
+            seats=[
+                SeatData(
+                    seat_index=0,
+                    user_id=HOST_ID,
+                    display_name="Host",
+                    ready="ready",
+                    connected=False,  # First player disconnected
+                    is_host=True,
+                ),
+                SeatData(
+                    seat_index=1,
+                    user_id=PLAYER_2_ID,
+                    display_name="Player 2",
+                    ready="ready",
+                    connected=True,
+                    is_host=False,
+                ),
+                SeatData(seat_index=2),
+                SeatData(seat_index=3),
+            ],
+            version=1,
+        )
+
+        mock_service = AsyncMock()
+        mock_service.get_room_snapshot.return_value = snapshot
+        mock_service.update_room_status_to_in_game = AsyncMock()
+        mock_get_room_service.return_value = mock_service
+        mock_get_game_state.return_value = None
+
+        # Settings with no grace period for tests
+        settings = MagicMock()
+        settings.TURN_SKIP_GRACE_PERIOD = 0
+        mock_get_settings.return_value = settings
+
+        # asyncio.sleep should be awaitable
+        mock_asyncio.sleep = AsyncMock()
+
+        # auto_play_turn returns state where P2 has the turn
+        auto_state = MagicMock()
+        auto_turn = MagicMock()
+        auto_turn.player_id = PLAYER_2_ID
+        auto_state.current_turn = auto_turn
+        auto_state.phase.value = "in_progress"
+        auto_state.players = [MagicMock(), MagicMock()]
+        auto_state.model_dump.return_value = {"phase": "in_progress", "auto_played": True}
+        auto_event = MagicMock()
+        auto_event.event_type = "dice_rolled"
+        auto_event.model_dump.return_value = {"event_type": "dice_rolled"}
+        turn_started = MagicMock()
+        turn_started.event_type = "turn_started"
+        turn_started.model_dump.return_value = {"event_type": "turn_started", "auto_played": False}
+        mock_auto_play.return_value = (auto_state, [turn_started, auto_event])
+
+        ctx = _make_context()
+        result = await handle_start_game(ctx)
+
+        assert result.success
+        mock_auto_play.assert_called_once()
+        # save_game_state called twice: once for initial state, once for auto-play
+        assert mock_save_game_state.call_count == 2


### PR DESCRIPTION
Closes #12 and #13 
This pull request introduces major improvements to the game's backend to support robust reconnection, persistent game state storage, and automatic turn handling for disconnected players. The changes include migrating game state storage to Redis with a 6-hour TTL, implementing auto-play logic for disconnected users, adding a new WebSocket handler and payload for game state sync, and enhancing test coverage. Additionally, new configuration options and documentation updates reflect these features.

**Persistent Game State & Reconnection:**

- Migrated game state storage from in-memory to Redis, using a 6-hour TTL and the key pattern `room:{room_id}:game_state`. Added functions for getting, saving, and deleting game state in `app/services/game/state.py`. This enables reconnection and state sync for users. [[1]](diffhunk://#diff-12c434cc504f6bed4275b825ca31c407165173540dd72e8be131cb0b8fbabd5bL1-R54) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L63-R64)
- On user authentication, if the room is in an active game, the server now auto-pushes the latest game state to reconnecting users via a new `GAME_STATE` WebSocket message and payload (`GameStatePayload`). [[1]](diffhunk://#diff-134a234d9f6029cd74a257a823322e06f53f46eec849a2388708aefe25d38bf8R149-R168) [[2]](diffhunk://#diff-cfe7656d66d2513ebf923ff0870b9302f7ccf7b3907f1921455e6c5f60d92752R172-R180) [[3]](diffhunk://#diff-134a234d9f6029cd74a257a823322e06f53f46eec849a2388708aefe25d38bf8R7-R11) [[4]](diffhunk://#diff-39d9d92dfe345a4313a1f7a5ed6a70c942b1495dad78eeb6a6962f9a81be2624R66) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R116-R119)

**Auto-Play for Disconnected Players:**

- Added `app/services/game/auto_play.py` to deterministically auto-play turns for disconnected players after a configurable grace period. The system picks the first available move and loops until the turn ends or the player is reconnected. [[1]](diffhunk://#diff-54046aa1a95d6523c86540c357466794f28cc2a5321e6711dac843af2f48f0f6R1-R106) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L63-R64) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R116-R119)
- Introduced the `TURN_SKIP_GRACE_PERIOD` config option (default 10s) to control the wait before auto-playing a turn.
- Updated the `TurnStarted` event to include an `auto_played` flag, signaling to clients when a turn was auto-played.

**Testing and Documentation:**

- Expanded the test suite to cover Redis-backed game state and auto-play logic, and updated documentation to describe the new reconnection and auto-move flows.
- Updated `CLAUDE.md` and code comments throughout to reflect the new architecture and flows. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L63-R64) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R116-R119) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L132-R138)

**Serialization and Code Quality:**

- Standardized serialization with `model_dump(mode="json")` for all game state and event payloads to ensure consistency across WebSocket and Redis operations. [[1]](diffhunk://#diff-bdca8bca1f75a22c2068ea38f9d0df763304cd70e8738b957011c2aa072051d4L145-R152) [[2]](diffhunk://#diff-cfe7656d66d2513ebf923ff0870b9302f7ccf7b3907f1921455e6c5f60d92752L159-R159)
- Minor formatting and code quality improvements across several files for readability and maintainability. [[1]](diffhunk://#diff-b90714429e5d9144f8db565f06a9b0694d531a5cbc04d43d317b2b38742c2579L47-R49) [[2]](diffhunk://#diff-b90714429e5d9144f8db565f06a9b0694d531a5cbc04d43d317b2b38742c2579R71) [[3]](diffhunk://#diff-b90714429e5d9144f8db565f06a9b0694d531a5cbc04d43d317b2b38742c2579R84) [[4]](diffhunk://#diff-30465b33dfb620abbe4763bc7fe88d4b36b7c0f0c2d4ea89d7bc41ffef5ada71L26-R32) [[5]](diffhunk://#diff-30465b33dfb620abbe4763bc7fe88d4b36b7c0f0c2d4ea89d7bc41ffef5ada71L886-R893) [[6]](diffhunk://#diff-30465b33dfb620abbe4763bc7fe88d4b36b7c0f0c2d4ea89d7bc41ffef5ada71L921-R928) [[7]](diffhunk://#diff-5ea8c456883519e276d460c2f9778fc82604f61d618f404103e707a5c88c2178L1211-R1211) [[8]](diffhunk://#diff-5ea8c456883519e276d460c2f9778fc82604f61d618f404103e707a5c88c2178L1223-R1221)

**Summary of Most Important Changes:**

**Persistent Game State & Reconnection**
- Migrated game state storage to Redis with 6-hour TTL, added get/save/delete logic in `app/services/game/state.py` and updated documentation. [[1]](diffhunk://#diff-12c434cc504f6bed4275b825ca31c407165173540dd72e8be131cb0b8fbabd5bL1-R54) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L63-R64)
- Implemented automatic game state push on user reconnect via new `GAME_STATE` message and `GameStatePayload`. [[1]](diffhunk://#diff-134a234d9f6029cd74a257a823322e06f53f46eec849a2388708aefe25d38bf8R149-R168) [[2]](diffhunk://#diff-cfe7656d66d2513ebf923ff0870b9302f7ccf7b3907f1921455e6c5f60d92752R172-R180) [[3]](diffhunk://#diff-134a234d9f6029cd74a257a823322e06f53f46eec849a2388708aefe25d38bf8R7-R11) [[4]](diffhunk://#diff-39d9d92dfe345a4313a1f7a5ed6a70c942b1495dad78eeb6a6962f9a81be2624R66) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R116-R119)

**Auto-Play for Disconnected Players**
- Added `app/services/game/auto_play.py` for auto-playing turns after a disconnect, with a deterministic move strategy. [[1]](diffhunk://#diff-54046aa1a95d6523c86540c357466794f28cc2a5321e6711dac843af2f48f0f6R1-R106) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L63-R64) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R116-R119)
- Introduced `TURN_SKIP_GRACE_PERIOD` config and documented the auto-move flow. [[1]](diffhunk://#diff-84f1a9419471e289c6b6e2b0209b329e20df6cef81d1f7f0a193ddc2fc6ad69dR37) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R116-R119)
- Marked auto-played turns in the `TurnStarted` event with a new `auto_played` flag.

**Testing and Documentation**
- Expanded tests for Redis game state and auto-play, and updated docs to describe new flows.

**Serialization and Code Quality**
- Standardized serialization with `model_dump(mode="json")` for all events and game state. [[1]](diffhunk://#diff-bdca8bca1f75a22c2068ea38f9d0df763304cd70e8738b957011c2aa072051d4L145-R152) [[2]](diffhunk://#diff-cfe7656d66d2513ebf923ff0870b9302f7ccf7b3907f1921455e6c5f60d92752L159-R159)
- Miscellaneous formatting and readability improvements. [[1]](diffhunk://#diff-b90714429e5d9144f8db565f06a9b0694d531a5cbc04d43d317b2b38742c2579L47-R49) [[2]](diffhunk://#diff-b90714429e5d9144f8db565f06a9b0694d531a5cbc04d43d317b2b38742c2579R71) [[3]](diffhunk://#diff-b90714429e5d9144f8db565f06a9b0694d531a5cbc04d43d317b2b38742c2579R84) [[4]](diffhunk://#diff-30465b33dfb620abbe4763bc7fe88d4b36b7c0f0c2d4ea89d7bc41ffef5ada71L26-R32) [[5]](diffhunk://#diff-30465b33dfb620abbe4763bc7fe88d4b36b7c0f0c2d4ea89d7bc41ffef5ada71L886-R893) [[6]](diffhunk://#diff-30465b33dfb620abbe4763bc7fe88d4b36b7c0f0c2d4ea89d7bc41ffef5ada71L921-R928) [[7]](diffhunk://#diff-5ea8c456883519e276d460c2f9778fc82604f61d618f404103e707a5c88c2178L1211-R1211) [[8]](diffhunk://#diff-5ea8c456883519e276d460c2f9778fc82604f61d618f404103e707a5c88c2178L1223-R1221)